### PR TITLE
Feat/32 data integracaoo com api sispubli

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,8 @@
       "name": "IFdex - Debug",
       "request": "launch",
       "type": "dart",
-      "args": ["--web-port", "5000"]
+      "deviceId": "chrome",
+      "args": ["--web-port=5000"]
     },
     {
       "name": "IFdex - Profile Mode (Performance)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,6 @@
       "name": "IFdex - Debug",
       "request": "launch",
       "type": "dart",
-      "deviceId": "chrome",
       "args": ["--web-port=5000"]
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,12 @@ O sistema adota o padrão de **Micro-frontends** para separar a gestão privada 
 
 ## 6. Regras de Segurança, Otimização e Upload
 
-Como o sistema operará na camada gratuita do Firebase, o App Flutter aplica travas rígidas:
+Como o sistema operará numa arquitetura híbrida (Firebase + Supabase):
 
 - **Formatos Aceitos:** Exclusivamente `.pdf`, `.jpg` ou `.png`.
-- **Limite de Tamanho e Armazenamento (Firestore-only):** O projeto **não utiliza Firebase Storage** (que exige plano pago). Os arquivos são armazenados na coleção `certificados_arquivos`. O tamanho máximo permitido para o upload pré-compressão é **5MB**, porém há um **limite restrito de 700KB após compressão** para caber no documento do Firestore. Caso o arquivo comprimido exceda 700KB, o upload será recusado e o usuário deverá usar um "Link Externo".
-- **Otimização Obrigatória:** O aplicativo Flutter deve executar a **compressão automática local** de imagens (`.jpg`/`.png`) antes de iniciar o tráfego de rede.
+- **Armazenamento de Arquivos:** O Firebase Firestore será usado exclusivamente para metadados (indexação, filtros, regras de negócio e deduplicação via Hash/UUID). Os arquivos binários pesados originais serão armazenados no **Supabase Storage**.
+- **Limites de Tamanho:** O projeto permite o upload de documentos de até **10MB** (PDFs e Imagens). Como não há o limite restrito de 1MB do Firestore, os PDFs do Sispubli podem ser salvos de forma íntegra.
+- **Otimização:** O aplicativo Flutter pode executar compressão de imagens (`.jpg`/`.png`) localmente, mas não é estritamente obrigatório reduzir para limites ínfimos devido à infraestrutura do Supabase.
 
 ## 7. Requisitos para a Entrega do Eixo 1 (05/05)
 
@@ -85,7 +86,7 @@ Foco em UI/UX, Componentização e Validações.
 - **Ano:** 1900 a 2026.
 - **Carga Horária:** Se preenchido, entre 1 e 5000 (disponível para ambas as origens).
 - **Tags:** Máx. 5 tags por certificado, máx. 20 caracteres por tag.
-- **Arquivo/Link:** Validação de tipo, tamanho pré-compressão (5MB), tamanho pós-compressão (limite 700KB para Firestore) ou formato de URL.
+- **Arquivo/Link:** Validação de tipo, tamanho máximo de **10MB** (Supabase Storage) ou formato de URL.
 
 **B. Gamificação e Estado (Contador de Itens):**
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Define que esses nomes são comandos, e não nomes de arquivos ou pastas
-.PHONY: install fix fix-lib fix-test fix-all format format-lib format-test format-all lint lint-lib lint-test lint-all test check check-all pre-commit build-web build-apk clean use-ssh use-https
+.PHONY: install fix fix-lib fix-test fix-all format format-lib format-test format-all lint lint-lib lint-test lint-all test check check-all pre-commit build-web build-apk clean use-ssh use-https generate watch
 
 
 # Instala o FVM, baixa o SDK, instala dependências e ativa o Lefthook na máquina
@@ -13,6 +13,15 @@ install:
 	@echo "------> 4/4 Blindando os commits com lefthook..."
 	npx lefthook install
 	@echo "------> Sucesso! Dependências instaladas e lefthook ativado!"
+
+# --- GERAÇÃO DE CÓDIGO ---
+# Roda o build_runner para gerar os arquivos .g.dart (Riverpod, JSON Serializable, etc)
+generate:
+	fvm dart run build_runner build -d
+
+# Roda o build_runner em modo observador (gera os arquivos em tempo real ao salvar)
+watch:
+	fvm dart run build_runner watch -d
 
 # --- FORMATAÇÃO ---
 # Formata apenas a pasta lib (mais rápido)

--- a/docs/arquitetura_spec.md
+++ b/docs/arquitetura_spec.md
@@ -73,6 +73,7 @@ lib/
 │   │   ├── data/                     # Camada de Dados
 │   │   │   ├── certificado_repository.dart
 │   │   │   ├── certificado_firestore_datasource.dart
+│   │   │   ├── certificado_arquivo_datasource.dart
 │   │   │   └── sispubli_datasource.dart
 │   │   │
 │   │   ├── models/                   # Entidades e DTOs
@@ -391,9 +392,10 @@ import 'package:ifdex/shared/providers/gamificacao_provider.dart';
 ```
 lib/features/certificados/
 ├── data/
-│   ├── certificado_repository.dart        # Abstrai Firestore + Sispubli
-│   ├── certificado_firestore_datasource.dart  # CRUD Firestore
-│   └── sispubli_datasource.dart           # GET HTTP → Sispubli API
+│   ├── certificado_repository.dart            # Abstrai Firestore + Storage + Sispubli
+│   ├── certificado_firestore_datasource.dart  # CRUD Firestore (Metadados)
+│   ├── certificado_arquivo_datasource.dart    # Supabase Storage (Upload PDFs/Imagens)
+│   └── sispubli_datasource.dart               # GET HTTP → Sispubli API
 ├── models/
 │   ├── certificado.dart                   # Entidade + validações + toMap/fromMap
 │   ├── certificado_types.dart             # Constantes de tipos
@@ -647,6 +649,7 @@ lib/
 | `lib/widgets/xp_header.dart`              | `lib/features/gamificacao/widgets/xp_header.dart`            | Mover         |
 | *(novo)*                                  | `lib/features/certificados/data/certificado_repository.dart` | Criar         |
 | *(novo)*                                  | `lib/features/certificados/data/certificado_firestore_datasource.dart` | Criar |
+| *(novo)*                                  | `lib/features/certificados/data/certificado_arquivo_datasource.dart` | Criar |
 | *(novo)*                                  | `lib/features/certificados/data/sispubli_datasource.dart`    | Criar         |
 | *(novo)*                                  | `lib/features/certificados/presentation/certificados_view_model.dart` | Criar |
 | *(novo)*                                  | `lib/features/gamificacao/presentation/gamificacao_view_model.dart` | Criar  |

--- a/docs/arquitetura_storage_ifdex.md
+++ b/docs/arquitetura_storage_ifdex.md
@@ -1,0 +1,181 @@
+# 🏛️ Especificação da Arquitetura de Storage (IFdex)
+
+> **Versão:** 1.0 (Arquitetura Definitiva)
+> **Stack:** Flutter (Client) + Firebase (Auth/Firestore) + Supabase (Storage) + Next.js (Proxy)
+> **Status:** ❄️ Aprovado e Congelado
+
+## 1. Visão Geral da Arquitetura (Híbrida e 100% Gratuita)
+
+O IFdex utiliza uma arquitetura descentralizada para maximizar performance e reduzir custos a zero, aproveitando o melhor de cada ecossistema:
+
+* **Identidade (Firebase Auth):** Gerencia os usuários (Anônimos ou Logados).
+* **Metadados e Lógica (Firestore):** Armazena os dados dos certificados (indexação rápida e deduplicação baseada no `id_unico` do Sispubli).
+* **Arquivos Pesados (Supabase Storage):** Contorna o limite de 1MB do Firestore, suportando PDFs/Imagens de até 10MB em um Bucket Privado.
+* **Compartilhamento (Next.js):** Atua como Proxy VIP, gerando Smart Links (`/c/{id}`) e consumindo o Supabase via *Service Role Key*.
+
+---
+
+## 2. O Segredo da Integração JWT (Contornando o Limite do Firebase Spark)
+
+O Supabase possui suporte nativo ao **Third-Party Auth** (gratuito até 50.000 MAUs). Isso permite que o Supabase valide assinaturas criptográficas dos tokens JWT gerados pelo Firebase.
+
+**O Problema do Plano Gratuito (Spark):** A documentação do Supabase sugere injetar `custom claims` (`role: authenticated`) via Firebase Cloud Functions, o que exige um plano pago (Blaze). 
+**A Nossa Solução:** Não usaremos *custom claims*. O Supabase identificará nosso usuário Flutter como `anon`, mas nossas políticas **RLS (Row Level Security)** vão interceptar e abrir o payload do JWT do Firebase para liberar o acesso, desde que o `sub` (UID do Firebase) seja igual ao nome da pasta.
+
+### 🔴 Configuração Obrigatória no Painel Supabase
+Para o RLS funcionar, o painel do Supabase deve estar configurado:
+1. Acesse **Authentication > Providers > Firebase Auth**.
+2. Ative a integração e insira o ID do projeto: `ifdex-app`.
+3. Isso instrui o Supabase a baixar as chaves JWKS do Google para decriptar os tokens.
+
+---
+
+## 3. Infraestrutura de Banco de Dados (SQL do Storage)
+
+O script abaixo é idempotente e provisiona a segurança absoluta do bucket.
+
+**Regras Aplicadas:**
+- Bucket estritamente PRIVADO.
+- O acesso exige validação do `iss` (Issuer) e `aud` (Audience) apontando para `ifdex-app`.
+- Impedimento de caminhos malformados (arquivos na raiz do bucket).
+- Isolamento criptográfico: O caminho do arquivo (`folder`) deve bater obrigatoriamente com o `sub` do token Firebase.
+
+```sql
+-- 1. Criação do Bucket Privado (Limite: 10MB, Apenas PDF e Imagens)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types) 
+VALUES ('certificados_arquivos', 'certificados_arquivos', false, 10485760, ARRAY['application/pdf', 'image/jpeg', 'image/png']::text[]) 
+ON CONFLICT (id) DO UPDATE SET file_size_limit = 10485760, public = false;
+
+-- Limpeza para idempotência
+DROP POLICY IF EXISTS "Upload seguro para usuarios Firebase" ON storage.objects;
+DROP POLICY IF EXISTS "Update seguro para usuarios Firebase" ON storage.objects;
+DROP POLICY IF EXISTS "Select seguro para usuarios Firebase" ON storage.objects;
+DROP POLICY IF EXISTS "Delete seguro para usuarios Firebase" ON storage.objects;
+
+-- 2. POLICY: INSERT (Upload Isolado)
+CREATE POLICY "Upload seguro para usuarios Firebase" 
+ON storage.objects FOR INSERT TO anon, authenticated
+WITH CHECK (
+  bucket_id = 'certificados_arquivos'
+  AND auth.jwt()->>'iss' = 'https://securetoken.google.com/ifdex-app'
+  AND auth.jwt()->>'aud' = 'ifdex-app'
+  AND (storage.foldername(name))[1] IS NOT NULL
+  AND (storage.foldername(name))[1] = auth.jwt()->>'sub'
+);
+
+-- 3. POLICY: UPDATE (Para `upsert: true` no Flutter funcionar)
+CREATE POLICY "Update seguro para usuarios Firebase" 
+ON storage.objects FOR UPDATE TO anon, authenticated
+USING (
+  bucket_id = 'certificados_arquivos'
+  AND auth.jwt()->>'iss' = 'https://securetoken.google.com/ifdex-app'
+  AND auth.jwt()->>'aud' = 'ifdex-app'
+  AND (storage.foldername(name))[1] = auth.jwt()->>'sub'
+)
+WITH CHECK (
+  bucket_id = 'certificados_arquivos'
+  AND auth.jwt()->>'iss' = 'https://securetoken.google.com/ifdex-app'
+  AND auth.jwt()->>'aud' = 'ifdex-app'
+  AND (storage.foldername(name))[1] IS NOT NULL
+  AND (storage.foldername(name))[1] = auth.jwt()->>'sub'
+);
+
+-- 4. POLICY: SELECT (Permite baixar os próprios PDFs no app Flutter)
+CREATE POLICY "Select seguro para usuarios Firebase" 
+ON storage.objects FOR SELECT TO anon, authenticated
+USING (
+  bucket_id = 'certificados_arquivos'
+  AND auth.jwt()->>'iss' = 'https://securetoken.google.com/ifdex-app'
+  AND auth.jwt()->>'aud' = 'ifdex-app'
+  AND (storage.foldername(name))[1] = auth.jwt()->>'sub'
+);
+
+-- 5. POLICY: DELETE (Exclusão pelo dono original)
+CREATE POLICY "Delete seguro para usuarios Firebase" 
+ON storage.objects FOR DELETE TO anon, authenticated
+USING (
+  bucket_id = 'certificados_arquivos'
+  AND auth.jwt()->>'iss' = 'https://securetoken.google.com/ifdex-app'
+  AND auth.jwt()->>'aud' = 'ifdex-app'
+  AND (storage.foldername(name))[1] = auth.jwt()->>'sub'
+);
+```
+
+---
+
+## 4. Implementação Client-Side (Flutter)
+
+A inicialização não deve usar `signInAnonymously()` nem criar múltiplos clientes. Usamos o recurso `accessToken` para garantir sincronia automática.
+
+### 4.1 Inicialização (`main.dart` ou `app.dart`)
+
+```dart
+await Supabase.initialize(
+  url: AppConstants.supabaseUrl,
+  anonKey: AppConstants.supabaseAnonKey,
+  accessToken: () async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return null;
+    return await user.getIdToken(); // Supabase consome o Firebase JWT automaticamente
+  },
+);
+```
+
+### 4.2 CertificadoArquivoDatasource
+
+```dart
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'dart:typed_data';
+
+class CertificadoArquivoDatasource {
+  final SupabaseClient _supabase;
+  final String _bucket = 'certificados_arquivos';
+
+  CertificadoArquivoDatasource(this._supabase);
+
+  Future<void> uploadArquivo(
+    String uid,
+    String certificadoId,
+    Uint8List bytes,
+    String fileName,
+  ) async {
+    // Lógica para definir extensão e contentType
+    // ...
+    final caminho = '$uid/$certificadoId$ext';
+    await _supabase.storage.from(_bucket).uploadBinary(
+      caminho, 
+      bytes,
+      fileOptions: FileOptions(upsert: true, contentType: contentType),
+    );
+  }
+
+  Future<Uint8List> downloadArquivo(String uid, String idHash) async {
+    final caminho = '$uid/$idHash.pdf';
+    return await _supabase.storage.from(_bucket).download(caminho);
+  }
+  
+  Future<void> deletarArquivo(String uid, String idHash) async {
+    final caminho = '$uid/$idHash.pdf';
+    await _supabase.storage.from(_bucket).remove([caminho]);
+  }
+}
+```
+
+---
+
+## 5. Roteamento Público (Next.js Proxy)
+
+Para exibir certificados de forma elegante via link de compartilhamento, o bucket é privado e a rota depende de validação.
+
+**Fluxo Obrigatório em `/api/certificado/[id]`:**
+
+1. Recebe a requisição com o `id_unico` (Hash).
+2. **Checa o Firestore:** O servidor acessa o Firestore via `Firebase Admin SDK` e busca o metadado.
+3. Se o metadado **NÃO** existir, aborta com `404 Not Found` (evita abuso da banda do Supabase).
+4. Se existir, extrai a `urlDocumento` ou o `UID` do dono.
+5. Utilizando o SDK do Supabase inicializado com a **Service Role Key** (ignora RLS), o Next.js faz o download do arquivo do caminho `uid/hash.pdf`.
+6. Envia os bytes (Stream) de volta para o cliente final.
+
+## 6. Prevenção de Arquivos Órfãos
+
+**Regra Operacional Crítica:** A persistência no sistema sempre ocorre na ordem: **Upload no Supabase primeiro -> Salva no Firestore depois.** Isso previne a existência de certificados na interface que não possuem arquivo anexado. Arquivos que subirem para o Supabase, mas falharem na etapa do Firestore (arquivos órfãos), serão tolerados em produção inicial e futuramente removidos por um Job de Garbage Collection agendado que cruzará a base do Storage com a base do Firestore.

--- a/docs/certificado_spec.md
+++ b/docs/certificado_spec.md
@@ -88,7 +88,7 @@ ifdex/
 | `tipoDescricao`   | `String`       | ✅           | Sim           | Categoria descritiva (ex: "Participação", "Ouvinte").                                                          |
 | `cargaHoraria`    | `int?`         | ❌           | Sim           | Horas do certificado. Se informada, deve estar entre 1 e 5000. **Proibida para Sispubli.**                     |
 | `urlDocumento`    | `String?`      | ❌           | Sim           | URL absoluta para o documento digital. Mutuamente exclusiva com `uploadDocumento`.                             |
-| `uploadDocumento` | `Uint8List?`   | ❌           | Sim           | Bytes do arquivo (PDF/JPG/PNG, máx. 5 MB). Mutuamente exclusivo com `urlDocumento`. **Proibido para Sispubli.**|
+| `uploadDocumento` | `Uint8List?`   | ❌           | Sim           | Bytes do arquivo (PDF/JPG/PNG, máx. 10 MB). Mutuamente exclusivo com `urlDocumento`. **Proibido para Sispubli.**|
 | `tags`            | `List<String>` | ✅           | Sim           | Lista de tags de categorização. Pode ser vazia (`[]`).                                                         |
 | `notaRelevancia`  | `int`          | ✅           | Sim           | Nota subjetiva de importância. Intervalo válido: 1–5.                                                          |
 

--- a/docs/checklist_eixo1.md
+++ b/docs/checklist_eixo1.md
@@ -79,7 +79,7 @@ grep -n "ListView.builder\|GridView.builder" lib/views/home_mobile_view.dart lib
 | Carga Horária | Opcional, 1 a 5000 | `certificado_form_view.dart` — validator do `_cargaHorariaCtrl` |
 | Tags | Máx 5 tags, 20 chars/tag | `certificado_form_view.dart` — validator do `_tagsCtrl` |
 | Link | Formato URL válido | `certificado_form_view.dart` — validator do `_linkCtrl` |
-| Arquivo | Máx 5MB, formatos pdf/jpg/png | `certificado_form_view.dart` — `_selecionarArquivo()` |
+| Arquivo | Máx 10MB, formatos pdf/jpg/png | `certificado_form_view.dart` — `_selecionarArquivo()` |
 
 **Como verificar:**
 
@@ -127,7 +127,7 @@ grep -n "AlertDialog\|showDialog" lib/widgets/remove_button.dart
 | ✅ | SnackBar ao salvar certificado | `lib/views/home_view.dart` — `_abrirFormulario()` exibe "Certificado salvo com sucesso!" |
 | ✅ | SnackBar ao remover certificado | `lib/views/home_view.dart` — `_removerCertificado()` exibe "Certificado removido." |
 | ✅ | SnackBar ao atualizar certificado | `lib/views/home_view.dart` — `_abrirFormulario()` e `_abrirDetalhes()` exibem "Certificado atualizado." |
-| ✅ | SnackBar de erro (upload > 5MB) | `lib/views/certificado_form_view.dart` — `_selecionarArquivo()` |
+| ✅ | SnackBar de erro (upload > 10MB) | `lib/views/certificado_form_view.dart` — `_selecionarArquivo()` |
 
 **Como verificar:**
 

--- a/docs/fluxo_certificado.md
+++ b/docs/fluxo_certificado.md
@@ -112,7 +112,7 @@ A flag `_isSispubli` controla o que é renderizado:
 | Carga Horária | Opcional, 1–5000 se preenchido       | ✅ 1–5000        |
 | Tags          | Máx 5 tags, máx 20 chars por tag    | ✅ 5 tags/20ch   |
 | URL           | Formato URL válido (se preenchido)   | URI absoluta     |
-| Upload        | .pdf/.jpg/.png, máx 5MB             | ✅ 5MB           |
+| Upload        | .pdf/.jpg/.png, máx 10MB            | ✅ 10MB          |
 | Relevância    | 1–5 (via estrelas)                   | ✅ 1–5           |
 
 ### 3.4 Comprovação: Exclusão Mútua (Apenas Manual)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,548 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sispubli API",
+    "description": "A Sispubli API fornece uma camada de abstração de alta performance sobre o sistema Sispubli/IFS, operando sob o padrão de **Vertical Slices**.\n\n**Pilares de Arquitetura:**\n- **Autenticação**: Gestão de identidade baseada em tokens Fernet com rotação de segredos e TTL estrito.\n- **Extração de Dados (Scraping)**: Motor de scraping resiliente que consolida informações do sistema upstream com otimização de cache.\n- **Privacidade e Segurança**: Blindagem de PII conforme LGPD através de hashing SHA-256 e mascaramento em repouso.\n- **Proxy de Documentos**: Túnel seguro de transporte de binários que elimina o vazamento de credenciais no downstream.\n",
+    "version": "2.1.0"
+  },
+  "paths": {
+    "/api/auth/token": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Geração de credenciais de acesso temporárias",
+        "description": "Normaliza, valida e criptografa o CPF do titular em um token de acesso efêmero. O token resultante utiliza criptografia Fernet (AES-128-CBC) e possui um tempo de vida (TTL) de 15 minutos.",
+        "operationId": "auth_token_api_auth_token_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "CPF invalido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Erro de validacao de campos",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit excedido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificados": {
+      "get": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Extração e listagem de certificados",
+        "description": "Realiza a extração iterativa de metadados de certificados no sistema upstream do IFS. O processo é autenticado via Bearer token, onde o CPF é descriptografado no backend para processar as requisições no Sispubli. As URLs de download resultantes são automaticamente convertidas em tickets protegidos, eliminando a manipulação de PII no downstream.",
+        "operationId": "listar_certificados_api_certificados_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificadosResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Token invalido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Nao autenticado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit excedido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Sispubli fora do ar",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/pdf/{ticket}": {
+      "get": {
+        "tags": [
+          "Proxy"
+        ],
+        "summary": "Streaming de documentos via túnel seguro",
+        "description": "Endpoint de alta segurança que executa o streaming bidirecional de documentos binários do sistema upstream. O ticket é decriptado no backend para resolver a URL original, aplicando validações rigorosas de SSRF e eliminando a necessidade de autenticação direta ou exposição de PII no downstream.",
+        "operationId": "tunnel_pdf_api_pdf__ticket__get",
+        "parameters": [
+          {
+            "name": "ticket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Ticket"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PDF streamado",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "application/pdf": {}
+            }
+          },
+          "400": {
+            "description": "Ticket invalido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "SSRF bloqueado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit excedido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream indisponivel",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Upstream timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Health Check",
+        "description": "Painel de saúde e diagnóstico da API.",
+        "operationId": "health_check__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CertificadoItem": {
+        "properties": {
+          "id_unico": {
+            "type": "string",
+            "title": "Id Unico",
+            "description": "Identificador único (SHA-256 + SALT) para anonimato (LGPD).",
+            "example": "a3f8c2d1e4b7091f6e2a5d8c3b1f4e7a9d..."
+          },
+          "titulo": {
+            "type": "string",
+            "title": "Titulo",
+            "description": "Titulo do evento ou certificado conforme registrado no Sispubli",
+            "example": "Participacao no(a) SEPEX 2023"
+          },
+          "url_download": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url Download",
+            "description": "Link direto para o endpoint de túnel da API. O acesso a este recurso consome um ticket criptografado efêmero, acionando o streaming direto do documento binário do sistema upstream, garantindo que nenhuma PII seja manipulada ou exposta no lado do cliente (downstream).",
+            "example": "https://api.sispubli.edu.br/api/pdf/38f92bd3a84e..."
+          },
+          "ano": {
+            "type": "integer",
+            "title": "Ano",
+            "description": "Ano de realizacao do evento, extraido dos parametros do Sispubli",
+            "example": 2023
+          },
+          "tipo_codigo": {
+            "type": "integer",
+            "title": "Tipo Codigo",
+            "description": "Codigo numerico do tipo de certificado (1=Participacao, 2=Autor, etc.)",
+            "example": 1
+          },
+          "tipo_descricao": {
+            "type": "string",
+            "title": "Tipo Descricao",
+            "description": "Descricao legivel do tipo de certificado",
+            "example": "Participacao"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id_unico",
+          "titulo",
+          "ano",
+          "tipo_codigo",
+          "tipo_descricao"
+        ],
+        "title": "CertificadoItem",
+        "description": "Representa um certificado individual no retorno da API.\n\nA url_download fornece o recurso final via túnel seguro, eliminando a\nnecessidade de processamento de PII no lado do cliente."
+      },
+      "CertificadosResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/CertificadosResult"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CertificadosResponse",
+        "description": "Envelope de resposta de sucesso — dados aninhados em 'data'."
+      },
+      "CertificadosResult": {
+        "properties": {
+          "usuario_id": {
+            "type": "string",
+            "title": "Usuario Id",
+            "description": "CPF mascarado do titular no formato ***.XXX.XXX-** (LGPD)",
+            "example": "***.456.789-**"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Quantidade total de certificados encontrados",
+            "example": 42
+          },
+          "certificados": {
+            "items": {
+              "$ref": "#/components/schemas/CertificadoItem"
+            },
+            "type": "array",
+            "title": "Certificados",
+            "description": "Lista completa de certificados disponiveis para o CPF informado"
+          }
+        },
+        "type": "object",
+        "required": [
+          "usuario_id",
+          "total"
+        ],
+        "title": "CertificadosResult",
+        "description": "Resultado consolidado da busca de certificados para um CPF."
+      },
+      "ErrorDetail": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "description": "Codigo de erro em snake_case para tratamento programatico",
+            "example": "invalid_cpf"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Mensagem descritiva do erro em portugues",
+            "example": "CPF deve conter exatamente 11 digitos numericos."
+          }
+        },
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "title": "ErrorDetail",
+        "description": "Detalhe de erro padronizado para facilitar tratamento no cliente."
+      },
+      "ErrorResponse": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ErrorDetail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "title": "ErrorResponse",
+        "description": "Envelope de resposta de erro — detalhes aninhados em 'error'."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Status geral da nossa API"
+          },
+          "environment": {
+            "type": "string",
+            "title": "Environment",
+            "description": "Ambiente de execução (development/production)"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version",
+            "description": "Versão atual da API"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp",
+            "description": "Momento exato da verificação (UTC)"
+          },
+          "security_configured": {
+            "type": "boolean",
+            "title": "Security Configured",
+            "description": "Indica se chaves críticas estão no .env"
+          },
+          "sispubli_online": {
+            "type": "boolean",
+            "title": "Sispubli Online",
+            "description": "Status de conectividade com o sistema upstream"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "environment",
+          "version",
+          "timestamp",
+          "security_configured",
+          "sispubli_online"
+        ],
+        "title": "HealthResponse",
+        "description": "Resposta do health check detalhado."
+      },
+      "TokenRequest": {
+        "properties": {
+          "cpf": {
+            "type": "string",
+            "title": "Cpf",
+            "description": "CPF do titular (11 dígitos). Aceita formatação com pontos e traço.",
+            "example": "74839210055"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cpf"
+        ],
+        "title": "TokenRequest",
+        "description": "Payload de entrada para geracao de token de sessao."
+      },
+      "TokenResponse": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token",
+            "description": "Token Fernet criptografado contendo o CPF do usuário (TTL 15 min)."
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token"
+        ],
+        "title": "TokenResponse",
+        "description": "Resposta da rota de autenticacao."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Auth",
+      "description": "Gestão de credenciais e tokens de acesso temporários."
+    },
+    {
+      "name": "Certificates",
+      "description": "Extração iterativa via processamento upstream no sistema Sispubli."
+    },
+    {
+      "name": "Proxy",
+      "description": "Túnel seguro para streaming de documentos binários."
+    },
+    {
+      "name": "System",
+      "description": "Monitoramento de integridade e diagnósticos de infraestrutura."
+    }
+  ]
+}

--- a/lib/features/certificados/data/certificado_arquivo_datasource.dart
+++ b/lib/features/certificados/data/certificado_arquivo_datasource.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'certificado_arquivo_datasource.g.dart';
@@ -9,98 +8,89 @@ part 'certificado_arquivo_datasource.g.dart';
 CertificadoArquivoDatasource certificadoArquivoDatasource(
   CertificadoArquivoDatasourceRef ref,
 ) {
-  return CertificadoArquivoDatasource(FirebaseFirestore.instance);
+  return CertificadoArquivoDatasource();
 }
 
-class FirestoreFileSizeException implements Exception {
+class StorageFileSizeException implements Exception {
   final String message;
-  FirestoreFileSizeException(this.message);
+  StorageFileSizeException(this.message);
 
   @override
   String toString() => message;
 }
 
-/// Datasource responsável pelo upload e download de binários no Firestore.
+/// Datasource responsável pelo upload e download de binários no Supabase Storage.
 class CertificadoArquivoDatasource {
-  final FirebaseFirestore _db;
-  static const int _maxSizeInBytes = 700 * 1024; // 700KB
+  final SupabaseClient _supabase = Supabase.instance.client;
+  final String _bucket = 'certificados_arquivos';
+  static const int _maxSizeInBytes = 10 * 1024 * 1024; // 10MB
 
-  CertificadoArquivoDatasource(this._db);
-
-  CollectionReference<Map<String, dynamic>> _collection(String uid) {
-    return _db.collection('users').doc(uid).collection('certificados_arquivos');
-  }
-
-  /// Faz o upload de um arquivo binário.
-  /// Se for imagem, tenta comprimir antes de salvar.
-  /// Lança [FirestoreFileSizeException] se exceder 700KB após compressão.
+  /// Faz o upload de um arquivo binário para o Supabase.
+  /// Lança [StorageFileSizeException] se exceder 10MB.
   Future<void> uploadArquivo(
     String uid,
     String certificadoId,
     Uint8List bytes,
-    String fileName,
+    String
+    fileName, // Mantido por compatibilidade com a assinatura, mas path é pdf/jpg
   ) async {
-    Uint8List dataToSave = bytes;
-
-    // Tentar comprimir se for JPG/PNG
-    final isImage =
-        fileName.toLowerCase().endsWith('.jpg') ||
-        fileName.toLowerCase().endsWith('.jpeg') ||
-        fileName.toLowerCase().endsWith('.png');
-
-    if (isImage) {
-      final format = fileName.toLowerCase().endsWith('.png')
-          ? CompressFormat.png
-          : CompressFormat.jpeg;
-
-      final compressed = await FlutterImageCompress.compressWithList(
-        bytes,
-        minWidth: 1920,
-        minHeight: 1080,
-        quality: 70,
-        format: format,
-      );
-
-      dataToSave = compressed;
-    }
-
-    if (dataToSave.lengthInBytes > _maxSizeInBytes) {
-      throw FirestoreFileSizeException(
-        'O arquivo excede o limite de 700KB mesmo após compressão. '
+    if (bytes.lengthInBytes > _maxSizeInBytes) {
+      throw StorageFileSizeException(
+        'O arquivo excede o limite de 10MB. '
         'Por favor, utilize a opção "Link Externo".',
       );
     }
 
-    String contentType = 'application/pdf';
+    // Identifica o formato a partir da extensão ou usa .pdf como padrão de backup
+    String ext = '.pdf';
     if (fileName.toLowerCase().endsWith('.png')) {
-      contentType = 'image/png';
+      ext = '.png';
     } else if (fileName.toLowerCase().endsWith('.jpg') ||
         fileName.toLowerCase().endsWith('.jpeg')) {
-      contentType = 'image/jpeg';
+      ext = '.jpg';
     }
 
-    await _collection(uid).doc(certificadoId).set({
-      'id': certificadoId,
-      'dados': Blob(dataToSave),
-      'nomeArquivo': fileName,
-      'contentType': contentType,
-      'tamanhoOriginal': bytes.lengthInBytes,
-      'tamanhoComprimido': dataToSave.lengthInBytes,
-    });
+    final caminho = '$uid/$certificadoId$ext';
+
+    // Configura o ContentType com base na extensão
+    String contentType = 'application/pdf';
+    if (ext == '.png') contentType = 'image/png';
+    if (ext == '.jpg') contentType = 'image/jpeg';
+
+    await _supabase.storage
+        .from(_bucket)
+        .uploadBinary(
+          caminho,
+          bytes,
+          fileOptions: FileOptions(upsert: true, contentType: contentType),
+        );
   }
 
-  /// Faz o download do arquivo binário sob demanda.
-  Future<Uint8List?> downloadArquivo(String uid, String certificadoId) async {
-    final doc = await _collection(uid).doc(certificadoId).get();
-    if (doc.exists && doc.data() != null) {
-      final blob = doc.data()!['dados'] as Blob?;
-      return blob?.bytes;
+  /// Faz o download do arquivo binário sob demanda do Supabase.
+  Future<Uint8List?> downloadArquivo(
+    String uid,
+    String certificadoId, {
+    String ext = '.pdf',
+  }) async {
+    try {
+      final caminho = '$uid/$certificadoId$ext';
+      return await _supabase.storage.from(_bucket).download(caminho);
+    } catch (e) {
+      return null;
     }
-    return null;
   }
 
-  /// Remove o arquivo do Firestore.
-  Future<void> removerArquivo(String uid, String certificadoId) async {
-    await _collection(uid).doc(certificadoId).delete();
+  /// Remove o arquivo do Supabase Storage.
+  Future<void> removerArquivo(
+    String uid,
+    String certificadoId, {
+    String ext = '.pdf',
+  }) async {
+    try {
+      final caminho = '$uid/$certificadoId$ext';
+      await _supabase.storage.from(_bucket).remove([caminho]);
+    } catch (e) {
+      // Ignora erro se o arquivo não existir
+    }
   }
 }

--- a/lib/features/certificados/models/certificado.dart
+++ b/lib/features/certificados/models/certificado.dart
@@ -122,14 +122,8 @@ class Certificado {
           'a instituição "IFS".',
         );
       }
-
-      if (uploadDocumento != null) {
-        throw ArgumentError(
-          'Certificados do Sispubli não aceitam '
-          'upload de arquivos, apenas '
-          'URL permanente.',
-        );
-      }
+      // uploadDocumento é permitido para Sispubli
+      // (importação baixa o PDF e faz upload no Supabase)
     }
 
     // 9. Validação de Formato de URL (Básica)

--- a/lib/features/certificados/presentation/certificado_form_view.dart
+++ b/lib/features/certificados/presentation/certificado_form_view.dart
@@ -109,12 +109,12 @@ class _CertificadoFormViewState extends ConsumerState<CertificadoFormView> {
     if (result == null) return;
     final file = result.files.first;
     final tamanhoMB = file.size / (1024 * 1024);
-    if (tamanhoMB > 5) {
+    if (tamanhoMB > 10) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: const AppText(
-            'O arquivo excede o limite de 5MB.',
+            'O arquivo excede o limite de 10MB.',
             color: AppColors.textOnPrimary,
           ),
           backgroundColor: Theme.of(context).colorScheme.error,
@@ -254,7 +254,7 @@ class _CertificadoFormViewState extends ConsumerState<CertificadoFormView> {
             ),
             const SizedBox(height: 4),
             AppText.label(
-              temArquivo ? 'Toque para alterar' : 'Máx 5MB',
+              temArquivo ? 'Toque para alterar' : 'Máx 10MB',
               color: AppColors.textMuted,
             ),
           ],

--- a/lib/features/home/presentation/home_view.dart
+++ b/lib/features/home/presentation/home_view.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
 import 'package:ifdex/features/certificados/presentation/certificado_form_view.dart';
+import 'package:ifdex/features/sispubli/presentation/sispubli_import_view.dart';
 import 'package:ifdex/features/auth/widgets/auth_status_widget.dart';
 import 'home_mobile_view.dart';
 import 'home_web_view.dart';
@@ -58,21 +60,148 @@ class HomeView extends ConsumerWidget {
           return const HomeWebView();
         },
       ),
-      floatingActionButton: isMobile
-          ? FloatingActionButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (_) => const CertificadoFormView(),
-                  ),
-                );
-              },
-              backgroundColor: AppColors.primary,
-              foregroundColor: AppColors.textOnPrimary,
-              child: const Icon(Icons.add),
-            )
-          : null,
+      floatingActionButton: isMobile ? const _SpeedDialFab() : null,
+    );
+  }
+}
+
+// ── SpeedDial FAB (Mobile Only) ─────────────────────
+
+class _SpeedDialFab extends StatefulWidget {
+  const _SpeedDialFab();
+
+  @override
+  State<_SpeedDialFab> createState() => _SpeedDialFabState();
+}
+
+class _SpeedDialFabState extends State<_SpeedDialFab>
+    with SingleTickerProviderStateMixin {
+  bool _isOpen = false;
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeInOut);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() {
+      _isOpen = !_isOpen;
+      if (_isOpen) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
+    });
+  }
+
+  void _navegar(Widget destino) {
+    _toggle();
+    Navigator.push(context, MaterialPageRoute<void>(builder: (_) => destino));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        // Mini-FABs
+        FadeTransition(
+          opacity: _animation,
+          child: ScaleTransition(
+            scale: _animation,
+            alignment: Alignment.bottomRight,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                _MiniAction(
+                  icon: Icons.cloud_download_outlined,
+                  label: 'Importar do IFS',
+                  onTap: () => _navegar(const SispubliImportView()),
+                ),
+                const SizedBox(height: 12),
+                _MiniAction(
+                  icon: Icons.edit_note,
+                  label: 'Digitar Manualmente',
+                  onTap: () => _navegar(const CertificadoFormView()),
+                ),
+                const SizedBox(height: 16),
+              ],
+            ),
+          ),
+        ),
+
+        // FAB principal
+        FloatingActionButton(
+          onPressed: _toggle,
+          backgroundColor: AppColors.primary,
+          foregroundColor: AppColors.textOnPrimary,
+          child: AnimatedRotation(
+            turns: _isOpen ? 0.125 : 0,
+            duration: const Duration(milliseconds: 200),
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Mini-FAB com label ──────────────────────────────
+
+class _MiniAction extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _MiniAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Material(
+          color: AppColors.surface,
+          elevation: 2,
+          borderRadius: BorderRadius.circular(8),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: AppText(label, fontSize: 13, fontWeight: FontWeight.w500),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        FloatingActionButton.small(
+          heroTag: label,
+          onPressed: onTap,
+          backgroundColor: AppColors.surface,
+          foregroundColor: AppColors.primary,
+          elevation: 2,
+          child: Icon(icon, size: 20),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/home/presentation/home_web_view.dart
+++ b/lib/features/home/presentation/home_web_view.dart
@@ -11,6 +11,7 @@ import 'package:ifdex/features/certificados/widgets/certificado_card.dart';
 import 'package:ifdex/features/certificados/presentation/certificado_details_view.dart';
 import 'package:ifdex/features/certificados/presentation/certificado_form_view.dart';
 import 'package:ifdex/features/auth/presentation/profile_view.dart';
+import 'package:ifdex/features/sispubli/presentation/sispubli_import_view.dart';
 
 import 'package:ifdex/shared/widgets/app_loading_state.dart';
 import 'package:ifdex/shared/widgets/app_error_state.dart';
@@ -265,6 +266,27 @@ class _TopBar extends ConsumerWidget {
             label: const AppText(
               'Novo Certificado',
               color: AppColors.textOnPrimary,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(width: 8),
+          OutlinedButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<void>(
+                  builder: (_) => const SispubliImportView(),
+                ),
+              );
+            },
+            icon: const Icon(
+              Icons.cloud_download_outlined,
+              size: 18,
+              color: AppColors.primary,
+            ),
+            label: const AppText(
+              'Importar do IFS',
+              color: AppColors.primary,
               fontWeight: FontWeight.w500,
             ),
           ),

--- a/lib/features/sispubli/data/sispubli_datasource.dart
+++ b/lib/features/sispubli/data/sispubli_datasource.dart
@@ -1,0 +1,195 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:ifdex/shared/constants/app_constants.dart';
+
+import 'sispubli_exceptions.dart';
+
+part 'sispubli_datasource.g.dart';
+
+@riverpod
+SispubliDatasource sispubliDatasource(SispubliDatasourceRef ref) {
+  return SispubliDatasource(AppConstants.sispubliBaseUrl);
+}
+
+/// DTO que espelha exatamente o JSON retornado pela API.
+///
+/// Isola o datasource do modelo de domínio — se a API
+/// mudar o formato, só o DTO e o parse mudam.
+class SispubliCertificadoDto {
+  final String idUnico;
+  final String titulo;
+  final String? urlDownload;
+  final int ano;
+  final int tipoCodigo;
+  final String tipoDescricao;
+
+  const SispubliCertificadoDto({
+    required this.idUnico,
+    required this.titulo,
+    this.urlDownload,
+    required this.ano,
+    required this.tipoCodigo,
+    required this.tipoDescricao,
+  });
+
+  factory SispubliCertificadoDto.fromJson(Map<String, dynamic> json) {
+    return SispubliCertificadoDto(
+      idUnico: json['id_unico'] as String,
+      titulo: json['titulo'] as String,
+      urlDownload: json['url_download'] as String?,
+      ano: json['ano'] as int,
+      tipoCodigo: json['tipo_codigo'] as int,
+      tipoDescricao: json['tipo_descricao'] as String,
+    );
+  }
+}
+
+/// DataSource HTTP responsável pela comunicação com a
+/// API do Sispubli utilizando o [Dio].
+///
+/// Possui 3 operações:
+/// 1. [autenticar] — gera token Fernet (TTL 15min)
+/// 2. [listarCertificados] — extrai metadados
+/// 3. [baixarPdf] — streaming do binário via túnel
+class SispubliDatasource {
+  final String baseUrl;
+  final Dio _dio;
+
+  SispubliDatasource(this.baseUrl) : _dio = Dio();
+
+  /// POST /api/auth/token
+  ///
+  /// Recebe um CPF (11 dígitos) e retorna o
+  /// `access_token` Fernet.
+  Future<String> autenticar(String cpf) async {
+    try {
+      final response = await _dio.post<Map<String, dynamic>>(
+        '$baseUrl/api/auth/token',
+        data: {'cpf': cpf},
+      );
+      final data = response.data!;
+      return data['access_token'] as String;
+    } on DioException catch (e) {
+      _tratarErroGeral(e);
+      _tratarErroAuth(e.response!);
+      rethrow;
+    }
+  }
+
+  /// GET /api/certificados [Bearer token]
+  ///
+  /// Retorna a lista de DTOs intermediários extraídos
+  /// do sistema upstream.
+  Future<List<SispubliCertificadoDto>> listarCertificados(String token) async {
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '$baseUrl/api/certificados',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+
+      final dataBody = response.data!;
+      final dataObj = dataBody['data'] as Map<String, dynamic>;
+      final lista = dataObj['certificados'] as List<dynamic>?;
+
+      if (lista == null) return [];
+
+      return lista
+          .cast<Map<String, dynamic>>()
+          .map(SispubliCertificadoDto.fromJson)
+          .toList();
+    } on DioException catch (e) {
+      _tratarErroGeral(e);
+      _tratarErroCertificados(e.response!);
+      rethrow;
+    }
+  }
+
+  /// GET /api/pdf/{ticket}
+  ///
+  /// Baixa os bytes crus do PDF via túnel seguro.
+  /// O [urlDownload] já contém a URL completa.
+  Future<Uint8List> baixarPdf(String urlDownload) async {
+    try {
+      final response = await _dio.get<List<int>>(
+        urlDownload,
+        options: Options(responseType: ResponseType.bytes),
+      );
+
+      return Uint8List.fromList(response.data!);
+    } on DioException catch (e) {
+      _tratarErroGeral(e);
+      _tratarErroPdf(e.response!);
+      rethrow;
+    }
+  }
+
+  // ── Tratamento de erros por endpoint ─────────────
+
+  /// Trata falhas onde o [Response] é nulo (ex: falhas de CORS, DNS,
+  /// timeout de conexão local). Dispara um [SispubliIndisponivelException]
+  /// para o ViewModel poder mostrar amigavelmente pro usuário.
+  void _tratarErroGeral(DioException e) {
+    if (e.response == null || e.type == DioExceptionType.connectionError) {
+      throw const SispubliIndisponivelException();
+    }
+  }
+
+  void _tratarErroAuth(Response<dynamic> response) {
+    switch (response.statusCode) {
+      case 200:
+        return;
+      case 400:
+      case 422:
+        throw const SispubliCpfInvalidoException();
+      case 429:
+        throw const SispubliRateLimitException();
+      default:
+        throw SispubliDesconhecidaException(
+          'Erro ${response.statusCode}: ${response.data}',
+        );
+    }
+  }
+
+  void _tratarErroCertificados(Response<dynamic> response) {
+    switch (response.statusCode) {
+      case 200:
+        return;
+      case 400:
+        throw const SispubliCpfInvalidoException();
+      case 401:
+        throw const SispubliNaoAutorizadoException();
+      case 429:
+        throw const SispubliRateLimitException();
+      case 502:
+        throw const SispubliIndisponivelException();
+      default:
+        throw SispubliDesconhecidaException(
+          'Erro ${response.statusCode}: ${response.data}',
+        );
+    }
+  }
+
+  void _tratarErroPdf(Response<dynamic> response) {
+    switch (response.statusCode) {
+      case 200:
+        return;
+      case 400:
+        throw const SispubliCpfInvalidoException();
+      case 403:
+        throw const SispubliNaoAutorizadoException();
+      case 429:
+        throw const SispubliRateLimitException();
+      case 502:
+        throw const SispubliIndisponivelException();
+      case 504:
+        throw const SispubliTimeoutException();
+      default:
+        throw SispubliDesconhecidaException(
+          'Erro ${response.statusCode}: ${response.data}',
+        );
+    }
+  }
+}

--- a/lib/features/sispubli/data/sispubli_datasource.g.dart
+++ b/lib/features/sispubli/data/sispubli_datasource.g.dart
@@ -1,30 +1,29 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'certificado_arquivo_datasource.dart';
+part of 'sispubli_datasource.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$certificadoArquivoDatasourceHash() =>
-    r'1ebfba8f42ad29d9c2d1575ed83e2581a6ab1552';
+String _$sispubliDatasourceHash() =>
+    r'c424f14a1951e25eb187da82065577ff83e2198e';
 
-/// See also [certificadoArquivoDatasource].
-@ProviderFor(certificadoArquivoDatasource)
-final certificadoArquivoDatasourceProvider =
-    AutoDisposeProvider<CertificadoArquivoDatasource>.internal(
-      certificadoArquivoDatasource,
-      name: r'certificadoArquivoDatasourceProvider',
+/// See also [sispubliDatasource].
+@ProviderFor(sispubliDatasource)
+final sispubliDatasourceProvider =
+    AutoDisposeProvider<SispubliDatasource>.internal(
+      sispubliDatasource,
+      name: r'sispubliDatasourceProvider',
       debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
           ? null
-          : _$certificadoArquivoDatasourceHash,
+          : _$sispubliDatasourceHash,
       dependencies: null,
       allTransitiveDependencies: null,
     );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef CertificadoArquivoDatasourceRef =
-    AutoDisposeProviderRef<CertificadoArquivoDatasource>;
+typedef SispubliDatasourceRef = AutoDisposeProviderRef<SispubliDatasource>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sispubli/data/sispubli_exceptions.dart
+++ b/lib/features/sispubli/data/sispubli_exceptions.dart
@@ -1,0 +1,45 @@
+/// Hierarquia de exceções tipadas para a API Sispubli.
+///
+/// Cada exceção mapeia um código de erro HTTP específico,
+/// permitindo que o ViewModel traduza em mensagens amigáveis.
+sealed class SispubliException implements Exception {
+  final String message;
+  const SispubliException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// 400 — CPF inválido ou malformado.
+class SispubliCpfInvalidoException extends SispubliException {
+  const SispubliCpfInvalidoException([super.message = 'CPF inválido.']);
+}
+
+/// 401 — Token expirado ou inválido.
+class SispubliNaoAutorizadoException extends SispubliException {
+  const SispubliNaoAutorizadoException([super.message = 'Não autorizado.']);
+}
+
+/// 429 — Rate limit excedido.
+class SispubliRateLimitException extends SispubliException {
+  const SispubliRateLimitException([super.message = 'Rate limit excedido.']);
+}
+
+/// 502 — Sispubli fora do ar (upstream indisponível).
+class SispubliIndisponivelException extends SispubliException {
+  const SispubliIndisponivelException([
+    super.message = 'Sispubli indisponível.',
+  ]);
+}
+
+/// 504 — Timeout ao comunicar com o Sispubli.
+class SispubliTimeoutException extends SispubliException {
+  const SispubliTimeoutException([super.message = 'Timeout do Sispubli.']);
+}
+
+/// Resposta inesperada (não mapeada).
+class SispubliDesconhecidaException extends SispubliException {
+  const SispubliDesconhecidaException([
+    super.message = 'Erro desconhecido na API.',
+  ]);
+}

--- a/lib/features/sispubli/presentation/sispubli_import_view.dart
+++ b/lib/features/sispubli/presentation/sispubli_import_view.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:ifdex/features/sispubli/data/sispubli_datasource.dart';
+import 'package:ifdex/features/sispubli/presentation/sispubli_import_view_model.dart';
+import 'package:ifdex/features/sispubli/presentation/sispubli_providers.dart';
+import 'package:ifdex/features/sispubli/widgets/sispubli_cpf_form.dart';
+import 'package:ifdex/features/sispubli/widgets/sispubli_import_progress.dart';
+import 'package:ifdex/features/sispubli/widgets/sispubli_selection_list.dart';
+import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
+import 'package:ifdex/shared/widgets/app_error_state.dart';
+import 'package:ifdex/shared/widgets/app_empty_state.dart';
+
+/// Tela de importação de certificados do Sispubli.
+/// Atua apenas como Controller de View, roteando as fases visuais
+/// de acordo com o estado do ViewModel e do Provider Computado.
+class SispubliImportView extends ConsumerStatefulWidget {
+  const SispubliImportView({super.key});
+
+  @override
+  ConsumerState<SispubliImportView> createState() => _SispubliImportViewState();
+}
+
+class _SispubliImportViewState extends ConsumerState<SispubliImportView> {
+  bool _importando = false;
+  int _progressoAtual = 0;
+  int _progressoTotal = 0;
+  ImportResult? _resultado;
+
+  Future<void> _iniciarImportacao(
+    List<SispubliCertificadoDto> selecionados,
+  ) async {
+    setState(() {
+      _importando = true;
+      _progressoAtual = 0;
+      _progressoTotal = selecionados.length;
+    });
+
+    final resultado = await ref
+        .read(sispubliImportViewModelProvider.notifier)
+        .importarSelecionados(selecionados, (int atual, int total) {
+          if (mounted) {
+            setState(() {
+              _progressoAtual = atual;
+              _progressoTotal = total;
+            });
+          }
+        });
+
+    if (!mounted) return;
+
+    setState(() {
+      _importando = false;
+      _resultado = resultado;
+    });
+
+    _mostrarResultado(resultado);
+  }
+
+  void _mostrarResultado(ImportResult resultado) {
+    final buffer = StringBuffer();
+
+    if (resultado.importados > 0) {
+      buffer.write(
+        '✅ ${resultado.importados} '
+        'importado(s) com sucesso',
+      );
+    }
+    if (resultado.semDocumento > 0) {
+      if (buffer.isNotEmpty) buffer.write(' | ');
+      buffer.write(
+        '⚠️ ${resultado.semDocumento} '
+        'sem documento',
+      );
+    }
+    if (resultado.erros > 0) {
+      if (buffer.isNotEmpty) buffer.write(' | ');
+      buffer.write(
+        '❌ ${resultado.erros} '
+        'com erro',
+      );
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(buffer.toString()),
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 4),
+      ),
+    );
+
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 1. Escuta a chamada da API (ViewModel)
+    final asyncState = ref.watch(sispubliImportViewModelProvider);
+
+    // 2. Escuta o Filtro Inteligente de Deduplicação (Provider Computado)
+    final disponiveis = ref.watch(certificadosSispubliDisponiveisProvider);
+
+    return PopScope(
+      canPop: !_importando,
+      child: Scaffold(
+        appBar: AppBar(
+          title: AppText(
+            _importando ? 'Importando...' : 'Importar do IFS',
+            color: AppColors.textOnPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        body: _importando
+            ? SispubliImportProgress(
+                progressoAtual: _progressoAtual,
+                progressoTotal: _progressoTotal,
+              )
+            : _resultado != null
+            ? const SizedBox.shrink()
+            : asyncState.when(
+                loading: () => const Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      CircularProgressIndicator(color: AppColors.primary),
+                      SizedBox(height: 16),
+                      AppText(
+                        'Consultando Sispubli...',
+                        color: AppColors.textSecondary,
+                      ),
+                    ],
+                  ),
+                ),
+                error: (Object err, StackTrace _) {
+                  final vm = ref.read(sispubliImportViewModelProvider.notifier);
+                  return AppErrorState(
+                    message: vm.traduzirErro(err),
+                    onRetry: () =>
+                        ref.invalidate(sispubliImportViewModelProvider),
+                  );
+                },
+                data: (importState) {
+                  // Fase 1: Sem estado = Mostrar formulário de CPF
+                  if (importState == null) {
+                    return const SispubliCpfForm();
+                  }
+
+                  // Fase 2: Deduplicado = Mostrar lista (ou empty se vazio)
+                  // Nota: O filtro "disponiveis" reage a adições e remoções
+                  // do provider global automaticamente.
+                  if (disponiveis.isEmpty) {
+                    return const AppEmptyState(
+                      message: 'Tudo importado!',
+                      subMessage:
+                          'Você já possui todos '
+                          'os certificados do '
+                          'Sispubli no seu cofre.',
+                    );
+                  }
+
+                  return SispubliSelectionList(
+                    disponiveis: disponiveis,
+                    onImportar: _iniciarImportacao,
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/sispubli/presentation/sispubli_import_view_model.dart
+++ b/lib/features/sispubli/presentation/sispubli_import_view_model.dart
@@ -1,0 +1,158 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:ifdex/features/certificados/data/certificado_repository.dart';
+import 'package:ifdex/features/sispubli/data/sispubli_datasource.dart';
+import 'package:ifdex/features/sispubli/data/sispubli_exceptions.dart';
+import 'package:ifdex/features/certificados/models/certificado.dart';
+import 'package:ifdex/features/certificados/presentation/certificados_view_model.dart';
+
+part 'sispubli_import_view_model.g.dart';
+
+/// Estado completo do fluxo de importação.
+class SispubliImportState {
+  final List<SispubliCertificadoDto> certificadosNovos;
+  final String token;
+
+  const SispubliImportState({
+    required this.certificadosNovos,
+    required this.token,
+  });
+}
+
+/// Resultado da importação em lote.
+class ImportResult {
+  final int importados;
+  final int semDocumento;
+  final int erros;
+
+  const ImportResult({
+    required this.importados,
+    required this.semDocumento,
+    required this.erros,
+  });
+}
+
+@riverpod
+class SispubliImportViewModel extends _$SispubliImportViewModel {
+  @override
+  Future<SispubliImportState?> build() async => null;
+
+  /// Fase 1: Autentica, busca certificados e deduplica.
+  Future<void> buscarCertificados(String cpf) async {
+    state = const AsyncLoading<SispubliImportState>();
+
+    try {
+      final datasource = ref.read(sispubliDatasourceProvider);
+
+      // 1. Autenticar
+      final token = await datasource.autenticar(cpf);
+
+      // 2. Listar certificados da API
+      final dtos = await datasource.listarCertificados(token);
+
+      state = AsyncData<SispubliImportState>(
+        SispubliImportState(certificadosNovos: dtos, token: token),
+      );
+    } on SispubliException catch (e) {
+      state = AsyncError<SispubliImportState>(e, StackTrace.current);
+    } on Exception catch (e) {
+      state = AsyncError<SispubliImportState>(e, StackTrace.current);
+    }
+  }
+
+  /// Fase 2: Download PDFs + persistência em lote.
+  Future<ImportResult> importarSelecionados(
+    List<SispubliCertificadoDto> selecionados,
+    void Function(int atual, int total) onProgresso,
+  ) async {
+    final datasource = ref.read(sispubliDatasourceProvider);
+    final repo = ref.read(certificadoRepositoryProvider);
+    // Token é preservado no state
+    final importState = state.value;
+    if (importState == null) {
+      return const ImportResult(importados: 0, semDocumento: 0, erros: 0);
+    }
+
+    var importados = 0;
+    var semDocumento = 0;
+    var erros = 0;
+
+    for (var i = 0; i < selecionados.length; i++) {
+      final dto = selecionados[i];
+
+      try {
+        // 1. Converter DTO → Certificado
+        final cert = Certificado.criar(
+          id: dto.idUnico,
+          origem: Origem.sispubli,
+          titulo: dto.titulo,
+          ano: dto.ano,
+          instituicao: 'IFS',
+          tipoDescricao: dto.tipoDescricao,
+          cargaHoraria: null,
+          urlDocumento: null,
+          tags: [],
+          notaRelevancia: 1,
+        );
+
+        // 2. Tentar baixar o PDF
+        if (dto.urlDownload != null && dto.urlDownload!.isNotEmpty) {
+          try {
+            final bytes = await datasource.baixarPdf(dto.urlDownload!);
+
+            // 3. Upload no Supabase via repository
+            cert.uploadDocumento = bytes;
+            await repo.adicionar(cert, fileName: '${cert.id}.pdf');
+            importados++;
+          } catch (_) {
+            // PDF falhou — salvar só metadados
+            await repo.adicionar(cert);
+            semDocumento++;
+          }
+        } else {
+          // Sem URL de download — salvar só metadados
+          await repo.adicionar(cert);
+          semDocumento++;
+        }
+      } catch (_) {
+        erros++;
+      }
+
+      onProgresso(i + 1, selecionados.length);
+    }
+
+    // Invalidar a lista principal para recarregar
+    ref.invalidate(certificadosViewModelProvider);
+
+    return ImportResult(
+      importados: importados,
+      semDocumento: semDocumento,
+      erros: erros,
+    );
+  }
+
+  /// Traduz exceções técnicas para mensagens de usuário.
+  String traduzirErro(Object erro) {
+    if (erro is SispubliCpfInvalidoException) {
+      return 'O CPF informado é inválido. '
+          'Verifique os dígitos.';
+    }
+    if (erro is SispubliNaoAutorizadoException) {
+      return 'Sessão expirada. Busque novamente.';
+    }
+    if (erro is SispubliRateLimitException) {
+      return 'Muitas tentativas. '
+          'Aguarde um momento.';
+    }
+    if (erro is SispubliIndisponivelException) {
+      return 'O Sispubli está fora do ar. '
+          'Tente mais tarde.';
+    }
+    if (erro is SispubliTimeoutException) {
+      return 'O Sispubli demorou para responder. '
+          'Tente novamente.';
+    }
+    return 'Ocorreu um erro inesperado. '
+        'Tente novamente.';
+  }
+}

--- a/lib/features/sispubli/presentation/sispubli_import_view_model.g.dart
+++ b/lib/features/sispubli/presentation/sispubli_import_view_model.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sispubli_import_view_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$sispubliImportViewModelHash() =>
+    r'a6dcd19412bf3554db426fd3b972de9122c45f04';
+
+/// See also [SispubliImportViewModel].
+@ProviderFor(SispubliImportViewModel)
+final sispubliImportViewModelProvider =
+    AutoDisposeAsyncNotifierProvider<
+      SispubliImportViewModel,
+      SispubliImportState?
+    >.internal(
+      SispubliImportViewModel.new,
+      name: r'sispubliImportViewModelProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$sispubliImportViewModelHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$SispubliImportViewModel =
+    AutoDisposeAsyncNotifier<SispubliImportState?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sispubli/presentation/sispubli_providers.dart
+++ b/lib/features/sispubli/presentation/sispubli_providers.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ifdex/features/sispubli/data/sispubli_datasource.dart';
+import 'package:ifdex/features/certificados/presentation/certificados_view_model.dart';
+import 'package:ifdex/features/sispubli/presentation/sispubli_import_view_model.dart';
+
+/// Provider Computado que atua como Filtro Inteligente.
+/// Observa o estado do fetch da API e os dados locais do usuário,
+/// retornando apenas os certificados do Sispubli que ainda não
+/// foram salvos no cofre do IFdex.
+final certificadosSispubliDisponiveisProvider =
+    Provider.autoDispose<List<SispubliCertificadoDto>>((ref) {
+      // 1. Observa o resultado do fetch
+      final importStateAsync = ref.watch(sispubliImportViewModelProvider);
+
+      if (importStateAsync.value == null) {
+        return const [];
+      }
+
+      final dtosDaApi = importStateAsync.value!.certificadosNovos;
+
+      // 2. Observa a base de dados em tempo real
+      final certificadosLocaisAsync = ref.watch(certificadosViewModelProvider);
+
+      final idsLocais = <String>{};
+      if (certificadosLocaisAsync is AsyncData) {
+        for (final cert in certificadosLocaisAsync.requireValue) {
+          idsLocais.add(cert.id);
+        }
+      }
+
+      // 3. Aplica o filtro de deduplicação reativamente
+      return dtosDaApi
+          .where((dto) => !idsLocais.contains(dto.idUnico))
+          .toList();
+    });

--- a/lib/features/sispubli/widgets/sispubli_cpf_form.dart
+++ b/lib/features/sispubli/widgets/sispubli_cpf_form.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:ifdex/features/sispubli/presentation/sispubli_import_view_model.dart';
+import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
+
+/// Fase 1: Formulário isolado para coletar o CPF.
+class SispubliCpfForm extends ConsumerStatefulWidget {
+  const SispubliCpfForm({super.key});
+
+  @override
+  ConsumerState<SispubliCpfForm> createState() => _SispubliCpfFormState();
+}
+
+class _SispubliCpfFormState extends ConsumerState<SispubliCpfForm> {
+  final _cpfController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    _cpfController.dispose();
+    super.dispose();
+  }
+
+  void _buscar() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final cpfLimpo = _cpfController.text.replaceAll(RegExp(r'\D'), '');
+    ref
+        .read(sispubliImportViewModelProvider.notifier)
+        .buscarCertificados(cpfLimpo);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 440),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(20),
+                  decoration: BoxDecoration(
+                    color: AppColors.primarySoft,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: const Icon(
+                    Icons.account_balance,
+                    size: 48,
+                    color: AppColors.primary,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                AppText.headline('Importar Certificados'),
+                const SizedBox(height: 8),
+                const AppText(
+                  'Busque seus certificados oficiais '
+                  'registrados no Sispubli do IFS.',
+                  color: AppColors.textSecondary,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 32),
+                TextFormField(
+                  controller: _cpfController,
+                  decoration: const InputDecoration(
+                    labelText: 'CPF',
+                    hintText: '00000000000',
+                    prefixIcon: Icon(Icons.badge_outlined),
+                  ),
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [
+                    FilteringTextInputFormatter.digitsOnly,
+                    LengthLimitingTextInputFormatter(11),
+                  ],
+                  validator: (value) {
+                    final limpo = (value ?? '').replaceAll(RegExp(r'\D'), '');
+                    if (limpo.length != 11) {
+                      return 'Informe os 11 dígitos do CPF.';
+                    }
+                    return null;
+                  },
+                  onFieldSubmitted: (_) => _buscar(),
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: _buscar,
+                    icon: const Icon(Icons.search, size: 20),
+                    label: const AppText(
+                      'Buscar Certificados',
+                      color: AppColors.textOnPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.infoSoft,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: const Row(
+                    children: [
+                      Icon(Icons.lock_outline, size: 16, color: AppColors.info),
+                      SizedBox(width: 8),
+                      Expanded(
+                        child: AppText(
+                          'Seu CPF não será armazenado. '
+                          'Usado apenas para consulta.',
+                          fontSize: 12,
+                          color: AppColors.info,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/sispubli/widgets/sispubli_import_progress.dart
+++ b/lib/features/sispubli/widgets/sispubli_import_progress.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
+
+/// Fase 3: Componente isolado para exibir o progresso
+/// da importação dos PDFs e salvamento em lote.
+class SispubliImportProgress extends StatelessWidget {
+  final int progressoAtual;
+  final int progressoTotal;
+
+  const SispubliImportProgress({
+    super.key,
+    required this.progressoAtual,
+    required this.progressoTotal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final progresso = progressoTotal > 0
+        ? progressoAtual / progressoTotal
+        : 0.0;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 440),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.cloud_download_outlined,
+                size: 48,
+                color: AppColors.primary,
+              ),
+              const SizedBox(height: 24),
+              AppText.headline('Importando...'),
+              const SizedBox(height: 8),
+              AppText(
+                '$progressoAtual de $progressoTotal',
+                color: AppColors.textSecondary,
+              ),
+              const SizedBox(height: 24),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(10),
+                child: LinearProgressIndicator(
+                  value: progresso,
+                  minHeight: 8,
+                  backgroundColor: AppColors.border,
+                  color: AppColors.primary,
+                ),
+              ),
+              const SizedBox(height: 24),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: AppColors.warningSoft,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.info_outline,
+                      size: 16,
+                      color: AppColors.warning,
+                    ),
+                    SizedBox(width: 8),
+                    AppText(
+                      'Não feche esta tela.',
+                      fontSize: 12,
+                      color: AppColors.warning,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/sispubli/widgets/sispubli_selection_list.dart
+++ b/lib/features/sispubli/widgets/sispubli_selection_list.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+
+import 'package:ifdex/features/sispubli/data/sispubli_datasource.dart';
+import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
+
+/// Fase 2: Componente isolado para selecionar DTOs através de checkboxes.
+/// Recebe a lista disponível (já deduplicada pelo Provider Computado)
+/// e avisa a view pai quando o usuário decide "Importar".
+class SispubliSelectionList extends StatefulWidget {
+  final List<SispubliCertificadoDto> disponiveis;
+  final ValueChanged<List<SispubliCertificadoDto>> onImportar;
+
+  const SispubliSelectionList({
+    super.key,
+    required this.disponiveis,
+    required this.onImportar,
+  });
+
+  @override
+  State<SispubliSelectionList> createState() => _SispubliSelectionListState();
+}
+
+class _SispubliSelectionListState extends State<SispubliSelectionList> {
+  final Set<String> _selecionados = {};
+  bool _selecionarTodos = false;
+
+  void _toggleTodos() {
+    setState(() {
+      if (_selecionarTodos) {
+        _selecionados.clear();
+        _selecionarTodos = false;
+      } else {
+        _selecionados.addAll(widget.disponiveis.map((d) => d.idUnico));
+        _selecionarTodos = true;
+      }
+    });
+  }
+
+  void _toggleItem(String id) {
+    setState(() {
+      if (_selecionados.contains(id)) {
+        _selecionados.remove(id);
+        _selecionarTodos = false;
+      } else {
+        _selecionados.add(id);
+      }
+    });
+  }
+
+  void _iniciarImportacao() {
+    final dtosParaImportar = widget.disponiveis
+        .where((d) => _selecionados.contains(d.idUnico))
+        .toList();
+    widget.onImportar(dtosParaImportar);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final qtdSelecionados = _selecionados.length;
+
+    return Column(
+      children: [
+        // Header com info e "Selecionar Todos"
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: const BoxDecoration(
+            color: AppColors.surface,
+            border: Border(bottom: BorderSide(color: AppColors.divider)),
+          ),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.primarySoft,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: AppText(
+                  '${widget.disponiveis.length} novo(s)',
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.primary,
+                ),
+              ),
+              const Spacer(),
+              TextButton.icon(
+                onPressed: _toggleTodos,
+                icon: Icon(
+                  _selecionarTodos ? Icons.deselect : Icons.select_all,
+                  size: 18,
+                ),
+                label: AppText(
+                  _selecionarTodos
+                      ? 'Desmarcar Todos'
+                      : 'Selecionar Todos '
+                            '(${widget.disponiveis.length})',
+                  fontSize: 13,
+                  color: AppColors.primary,
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        // Lista com checkboxes
+        Expanded(
+          child: ListView.builder(
+            itemCount: widget.disponiveis.length,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            itemBuilder: (context, index) {
+              final dto = widget.disponiveis[index];
+              final selecionado = _selecionados.contains(dto.idUnico);
+
+              return Card(
+                margin: const EdgeInsets.symmetric(vertical: 4),
+                child: CheckboxListTile(
+                  value: selecionado,
+                  onChanged: (_) => _toggleItem(dto.idUnico),
+                  activeColor: AppColors.primary,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  title: AppText(dto.titulo, fontWeight: FontWeight.w500),
+                  subtitle: Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Row(
+                      children: [
+                        _Tag(label: dto.tipoDescricao),
+                        const SizedBox(width: 8),
+                        _Tag(label: '${dto.ano}'),
+                        if (dto.urlDownload != null) ...[
+                          const SizedBox(width: 8),
+                          const Icon(
+                            Icons.picture_as_pdf,
+                            size: 14,
+                            color: AppColors.error,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  secondary: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: AppColors.primarySoft,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: const Icon(
+                      Icons.school_outlined,
+                      color: AppColors.primary,
+                      size: 20,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+
+        // Botão de importar
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: const BoxDecoration(
+            color: AppColors.surface,
+            border: Border(top: BorderSide(color: AppColors.divider)),
+          ),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: qtdSelecionados > 0 ? _iniciarImportacao : null,
+              icon: const Icon(Icons.cloud_download_outlined, size: 20),
+              label: AppText(
+                qtdSelecionados > 0
+                    ? 'Importar $qtdSelecionados Selecionado(s)'
+                    : 'Selecione certificados',
+                color: qtdSelecionados > 0
+                    ? AppColors.textOnPrimary
+                    : AppColors.textDisabled,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Tag extends StatelessWidget {
+  final String label;
+
+  const _Tag({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.background,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: AppText(label, fontSize: 11, color: AppColors.textSecondary),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:ifdex/firebase_options.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:ifdex/shared/constants/app_constants.dart';
 import 'package:ifdex/app/app.dart';
 import 'package:ifdex/app/app_provider_observer.dart';
 
@@ -11,6 +14,16 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  await Supabase.initialize(
+    url: AppConstants.supabaseUrl,
+    publishableKey: AppConstants.supabaseAnonKey,
+    accessToken: () async {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return null;
+      return await user.getIdToken();
+    },
+  );
 
   runApp(
     ProviderScope(

--- a/lib/shared/constants/app_constants.dart
+++ b/lib/shared/constants/app_constants.dart
@@ -1,0 +1,11 @@
+class AppConstants {
+  /// Base URL da API do Sispubli
+  static const String sispubliBaseUrl = 'https://sispubli-api.vercel.app';
+
+  /// URL do Projeto Supabase (API URL que aparece no seu painel)
+  static const String supabaseUrl = 'https://ywtsipbqcirptqflkeut.supabase.co';
+
+  /// Publishable Key / Anon Key do Supabase (A chave 'anon' / 'public')
+  static const String supabaseAnonKey =
+      'sb_publishable_KWurjsEfsbb-6rA-P1E2Vg__FWFkOHT';
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -369,6 +369,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.2"
+  app_links:
+    dependency: transitive
+    description:
+      name: app_links
+      sha256: "3462d9defc61565fde4944858b59bec5be2b9d5b05f20aed190adb3ad08a7abc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -305,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0+7.7.0"
+  dart_jsonwebtoken:
+    dependency: transitive
+    description:
+      name: dart_jsonwebtoken
+      sha256: ad84e60181696513d04d5f2078e0bbc20365b911f46f647797317414bdc88fbe
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   dart_style:
     dependency: transitive
     description:
@@ -313,6 +353,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.4.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -512,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  functions_client:
+    dependency: transitive
+    description:
+      name: functions_client
+      sha256: f3304ca860169f2e8acc5eceb0cd5d788cdac9551497b8326313a8130c14f24e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   glob:
     dependency: transitive
     description:
@@ -576,6 +640,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.4+4"
+  gotrue:
+    dependency: transitive
+    description:
+      name: gotrue
+      sha256: a6120dee1e77d0e31a788d3db761c4ae514be8a9662beec0b7c883e74e391091
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.22.0"
   graphs:
     dependency: transitive
     description:
@@ -584,6 +656,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   hooks:
     dependency: transitive
     description:
@@ -672,6 +752,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  jwt_decode:
+    dependency: transitive
+    description:
+      name: jwt_decode
+      sha256: d2e9f68c052b2225130977429d30f187aa1981d789c76ad104a32243cfdebfbb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -768,6 +856,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  passkeys:
+    dependency: transitive
+    description:
+      name: passkeys
+      sha256: "09e55fed6ff40499e6bb901da13ab58985e966b05fb91da8323ac081683e97ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.20.0"
+  passkeys_android:
+    dependency: transitive
+    description:
+      name: passkeys_android
+      sha256: "4286322398df7cc74b7503e9d638fab7885e56986689a2f683731da473f23f85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.0"
+  passkeys_darwin:
+    dependency: transitive
+    description:
+      name: passkeys_darwin
+      sha256: "3a9008714d392af79d93f5a657fa93b76edea515e2cf71e25da3567aec663ae7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
+  passkeys_doctor:
+    dependency: transitive
+    description:
+      name: passkeys_doctor
+      sha256: "83cbed79bff4b63b54a3f3b5d80aa8f68c9009b6a85fb432b5bb7918bb47c681"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
+  passkeys_platform_interface:
+    dependency: transitive
+    description:
+      name: passkeys_platform_interface
+      sha256: "10fd4dd6779f6ca928adc2289e05ce0877250e68f2cc584abd2e3fcd6952e454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
+  passkeys_web:
+    dependency: transitive
+    description:
+      name: passkeys_web
+      sha256: aa32224b289601f6894f243b24d21e56f90d632711bb4db1dedf4ea29f562de4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
+  passkeys_windows:
+    dependency: transitive
+    description:
+      name: passkeys_windows
+      sha256: acea5ff790a8c6de0366d1b87dd591c0d6e6770bf17d62efbd9fac7747724cc7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   path:
     dependency: transitive
     description:
@@ -848,6 +1008,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   pool:
     dependency: transitive
     description:
@@ -864,6 +1032,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  postgrest:
+    dependency: transitive
+    description:
+      name: postgrest
+      sha256: "83bfb9cb4a8a15a01f087bf472e14760f722bf531498a9c428df100c649c028d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.2"
   pub_semver:
     dependency: transitive
     description:
@@ -880,6 +1056,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  realtime_client:
+    dependency: transitive
+    description:
+      name: realtime_client
+      sha256: ac96ac76522de7c7ac30eb99f50899186ff4ac7d426f6bc7997a002e24f0e3a2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.0"
   record_use:
     dependency: transitive
     description:
@@ -888,6 +1072,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  retry:
+    dependency: transitive
+    description:
+      name: retry
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   riverpod:
     dependency: transitive
     description:
@@ -936,6 +1128,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -989,6 +1237,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  storage_client:
+    dependency: transitive
+    description:
+      name: storage_client
+      sha256: "2079d182a3806a9a7be746fee6603bbea207adbc3cc6f11c670f5d1f3eb5263e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.7"
   stream_channel:
     dependency: transitive
     description:
@@ -1013,6 +1269,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  supabase:
+    dependency: transitive
+    description:
+      name: supabase
+      sha256: "04babf8ece84d9ca528a9d9187b37899ce38ffabb6cd4ef28c6db0e679b0aca9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  supabase_flutter:
+    dependency: "direct main"
+    description:
+      name: supabase_flutter
+      sha256: c5f9cc95162fd057be851ce38a0d54a0391cecad3a6ddfce1314e47f89a382f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1045,6 +1317,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  ua_client_hints:
+    dependency: transitive
+    description:
+      name: ua_client_hints
+      sha256: e6e302bb7c21d6a90023db61e0ec413f0810ce341bb7e2ab447ff5d61ec3d87e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.7.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1181,6 +1461,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1205,6 +1493,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  yet_another_json_isolate:
+    dependency: transitive
+    description:
+      name: yet_another_json_isolate
+      sha256: eaa26beb5990b25a49d942374fd5a0c5aa67a837e03b14b4c26134aaa1ed01a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
 sdks:
   dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   cloud_firestore: ^6.6.0
   google_sign_in: ^6.2.1
   flutter_image_compress: ^2.4.0
+  supabase_flutter: ^2.15.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   google_sign_in: ^6.2.1
   flutter_image_compress: ^2.4.0
   supabase_flutter: ^2.15.0
+  dio: ^5.9.2
 
 dev_dependencies:
   flutter_test:

--- a/test/features/certificados/models/certificado_test.dart
+++ b/test/features/certificados/models/certificado_test.dart
@@ -433,23 +433,14 @@ void main() {
       expect(cert.cargaHoraria, 40);
     });
 
-    test('#24 Deve lançar erro se a Origem for Sispubli '
-        'e possuir uploadDocumento', () {
-      final p = baseSispubli()
-        ..['uploadDocumento'] = Uint8List.fromList([1, 2, 3]);
+    test('#24 Deve aceitar uploadDocumento para a Origem Sispubli '
+        '(proxy download)', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final p = baseSispubli()..['uploadDocumento'] = bytes;
 
-      expect(
-        () => criar(p),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            'Certificados do Sispubli não aceitam '
-                'upload de arquivos, apenas '
-                'URL permanente.',
-          ),
-        ),
-      );
+      final cert = criar(p);
+      expect(cert.uploadDocumento, bytes);
+      expect(cert.origem, Origem.sispubli);
     });
   });
 

--- a/web/index.html
+++ b/web/index.html
@@ -32,6 +32,9 @@
 
   <title>IFdex</title>
   <link rel="manifest" href="manifest.json">
+  
+  <!-- Supabase/Corbado Passkeys Web SDK (Obrigatório pelo supabase_flutter na Web) -->
+  <script src="https://github.com/corbado/flutter-passkeys/releases/download/2.4.0/bundle.js"></script>
 </head>
 <body>
   <!--


### PR DESCRIPTION
<!-- AGENTE MCP / IA: Ao analisar este Pull Request, verifique de forma autônoma se o código viola a regra de não utilizar tipos 'dynamic'. Se o PR alterar a pasta lib/views/ ou lib/widgets/, exija a presença de screenshots de prova visual no corpo da descrição abaixo. -->

# 🔗 Link para a Issue resolvida

Closes #32

## 📋 Checklist Obrigatório

Antes de colocar seu PR para revisão, ateste que cumpriu os padrões do repositório:

- [x] Eu rodei `make check` e não há erros de Linter ou formatação.
- [x] Eu escrevi testes automatizados para essa alteração (se aplicável).
- [x] Meu código não utiliza `dynamic` e respeita as regras de tipagem estrita.

---

## 🖼️ Prova Visual (A Regra do "Me Prove")

Se você alterou elementos de interface do Flutter (`lib/views/` ou `lib/widgets/`), é **obrigatório** anexar evidências visuais do Antes e Depois. Isso elimina o atrito de compilação apenas para revisão de UI.

> *[Arraste as capturas de tela das 3 novas telas do Sispubli aqui (Tela de CPF, Tela de Lista com os Checkboxes, e a Tela de Loading)]*

---

## 🤔 Reflexão Estratégica

Evite a "aprovação no piloto automático" respondendo:

**1. Qual foi o caso extremo (edge case) que você considerou ao codificar essa funcionalidade ou teste?**
> Ao arquitetar o "Filtro Inteligente de Deduplicação" (`certificadosSispubliDisponiveisProvider`), lidei com o cenário onde o banco de dados do usuário está vazio (`AsyncLoading` ou listas vazias) durante uma consulta na API. Tratei isso garantindo que a filtragem reaja estritamente apenas quando os dados locais resolvem em `AsyncData`, evitando falhas de estado ou o engessamento da UI. Além disso, criamos um God Widget e o despedaçamos para seguir o princípio de "Responsabilidade Única" (SRP), prevenindo *Feature Bloat* e engatilhando os testes com perfeição.

**2. Foi deixado algum débito técnico consciente nesta entrega? Se sim, qual e o porquê?**
> Sim. A deduplicação entre os IDs do Firebase local e a requisição da API Sispubli ocorre na memória (RAM) varrendo as chaves do Firestore e da lista retornada, usando um `Set` em tempo real. Embora não seja a operação O(1) de cache mais complexa possível do mundo, a volumetria máxima de certificados em um portfólio acadêmico não exigirá otimizações extremas a ponto de criar engasgos na Thread principal (UI Jank). O código "simples" ganha do código hiper-optimizado aqui.
