### PR TITLE
Feat/34 busca e pesquisa de certificados

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Foco em UI/UX, Componentização e Validações.
 
 **A. Validações do Formulário:**
 
-- **Título:** Obrigatório (max 100 char).
+- **Título:** Obrigatório (max 255 char).
 - **Ano:** 1900 a 2026.
 - **Carga Horária:** Se preenchido, entre 1 e 5000 (disponível para ambas as origens).
 - **Tags:** Máx. 5 tags por certificado, máx. 20 caracteres por tag.
@@ -109,7 +109,7 @@ Para cumprir o requisito obrigatório de **"Manipulação de Estado / Contador d
 > Para documentação detalhada do fluxo Detalhes → Edição (incluindo comportamento de botões, bloqueios condicionais e merge de dados), consulte [`docs/fluxo_certificado.md`](docs/fluxo_certificado.md).
 
 - **Dinâmica do Formulário (Exclusão Mútua):** Se "URL" for preenchida, esconde "Upload", e vice-versa.
-- **Prevenção de Erros:** Disparar **`AlertDialog`** para confirmar a intenção de exclusão de certificados.
+- **Prevenção de Erros:** Disparar **`AlertDialog`** para confirmar a intenção de exclusão de certificados. Bloquear botões com estado de carregamento (`isLoading`) para evitar duplo-clique em requisições de rede.
 - **Feedback de Sistema:** Uso de **`SnackBars`** para notificações de sucesso (ex: "Certificado salvo") ou erros de validação.
 - **Compartilhamento Híbrido:** Utilizar o pacote **`share_plus`** para acionar a gaveta nativa, garantindo sempre a opção explícita de **"Copiar Link"** (compatibilidade Web/Mobile).
 

--- a/docs/certificado_spec.md
+++ b/docs/certificado_spec.md
@@ -82,7 +82,7 @@ ifdex/
 |:------------------|:---------------|:------------:|:-------------:|:---------------------------------------------------------------------------------------------------------------|
 | `id`              | `String`       | ✅           | Não (`final`) | Identificador único. SHA-256 (Sispubli) ou UUID v4 (Manual).                                                   |
 | `origem`          | `Origem`       | ✅           | Não (`final`) | Enum que classifica a procedência: `sispubli` ou `manual`.                                                     |
-| `titulo`          | `String`       | ✅           | Sim           | Nome do certificado. Máximo de 100 caracteres.                                                                 |
+| `titulo`          | `String`       | ✅           | Sim           | Nome do certificado. Máximo de 255 caracteres.                                                                 |
 | `ano`             | `int`          | ✅           | Sim           | Ano de emissão. Intervalo válido: 1900–2026.                                                                   |
 | `instituicao`     | `String`       | ✅           | Sim           | Instituição emissora. Fixo como "IFS" para origem Sispubli.                                                    |
 | `tipoDescricao`   | `String`       | ✅           | Sim           | Categoria descritiva (ex: "Participação", "Ouvinte").                                                          |
@@ -117,7 +117,7 @@ as regras estão documentadas na ordem de execução do Factory.
 - O campo `titulo` é **obrigatório**.
 - Não pode ser uma string vazia nem composta apenas por espaços em
   branco (avaliado via `titulo.trim().isEmpty`).
-- O comprimento máximo é de **100 caracteres** (inclusive).
+- O comprimento máximo é de **255 caracteres** (inclusive).
 - **Erro:** `ArgumentError` com mensagem descritiva.
 
 ### 4.2 Validação de Ano
@@ -190,7 +190,7 @@ aplicadas para refletir as limitações da API oficial:
 
 ```mermaid
 flowchart TD
-    A["Certificado.criar()"] --> B{"Título válido?<br/>(não vazio, ≤ 100 chars)"}
+    A["Certificado.criar()"] --> B{"Título válido?<br/>(não vazio, ≤ 255 chars)"}
     B -- Não --> X1["❌ ArgumentError"]
     B -- Sim --> C{"Ano ∈ [1900, 2026]?"}
     C -- Não --> X2["❌ ArgumentError"]
@@ -257,7 +257,7 @@ Validam strings obrigatórias, limites de comprimento e formato.
 | #  | Caso de Teste                        | Entrada                                          | Resultado Esperado   |
 |:-: |:-------------------------------------|:-------------------------------------------------|:---------------------|
 | 12 | Título vazio                         | `''` ou `'   '` (espaços)                        | `ArgumentError`      |
-| 13 | Título acima de 100 caracteres       | String com 101 chars                             | `ArgumentError`      |
+| 13 | Título acima de 255 caracteres       | String com 256 chars                             | `ArgumentError`      |
 | 14 | URL com formato inválido             | `'wwwgooglecom'` ou `'link falso'`               | `ArgumentError`      |
 | 15 | ID, Instituição ou Tipo vazios       | Strings vazias nos campos obrigatórios           | `ArgumentError`      |
 | 16 | Sispubli com instituição ≠ IFS       | `instituicao = 'Udemy'` com `Origem.sispubli`    | `ArgumentError`      |
@@ -272,7 +272,7 @@ testando os valores exatos das fronteiras.
 | 17 | Ano nos limites exatos                | `ano = 1900` e `ano = 2026`                     | ✅ Instância criada    |
 | 18 | Carga horária nos limites exatos      | `cargaHoraria = 1` e `cargaHoraria = 5000`      | ✅ Instância criada    |
 | 19 | Nota de relevância nos limites exatos | `notaRelevancia = 1` e `notaRelevancia = 5`     | ✅ Instância criada    |
-| 20 | Título com exatamente 100 caracteres  | String de 100 chars                             | ✅ Instância criada    |
+| 20 | Título com exatamente 255 caracteres  | String de 255 chars                             | ✅ Instância criada    |
 
 ### 5.6 Casos de Borda (Arrays e Nulls)
 

--- a/docs/checklist_eixo1.md
+++ b/docs/checklist_eixo1.md
@@ -74,7 +74,7 @@ grep -n "ListView.builder\|GridView.builder" lib/views/home_mobile_view.dart lib
 
 | Campo | Regra | Local |
 |:----- |:----- |:----- |
-| Título | Obrigatório, máx 100 chars | `certificado_form_view.dart` — validator do `_tituloCtrl` |
+| Título | Obrigatório, máx 255 chars | `certificado_form_view.dart` — validator do `_tituloCtrl` |
 | Ano | 1900 a ano atual | `certificado_form_view.dart` — validator do `_anoCtrl` |
 | Carga Horária | Opcional, 1 a 5000 | `certificado_form_view.dart` — validator do `_cargaHorariaCtrl` |
 | Tags | Máx 5 tags, 20 chars/tag | `certificado_form_view.dart` — validator do `_tagsCtrl` |

--- a/docs/fluxo_certificado.md
+++ b/docs/fluxo_certificado.md
@@ -106,7 +106,7 @@ A flag `_isSispubli` controla o que é renderizado:
 
 | Campo         | Regra de Validação                   | Limite no Modelo |
 | :------------ | :----------------------------------- | :--------------- |
-| Título        | Obrigatório, máx 100 chars          | ✅ max 100       |
+| Título        | Obrigatório, máx 255 chars          | ✅ max 255       |
 | Instituição   | Obrigatório                          | Não-vazio        |
 | Ano           | Obrigatório, entre 1900 e ano atual | ✅ 1900–2026     |
 | Carga Horária | Opcional, 1–5000 se preenchido       | ✅ 1–5000        |

--- a/firestore.rules
+++ b/firestore.rules
@@ -12,14 +12,14 @@ service cloud.firestore {
         
         allow create: if isOwner(userId)
           && request.resource.data.keys().hasAll(['id', 'origem', 'titulo', 'ano', 'instituicao', 'tags'])
-          && request.resource.data.titulo.size() <= 100
+          && request.resource.data.titulo.size() <= 255
           && request.resource.data.ano >= 1900 && request.resource.data.ano <= 2026
           && request.resource.data.tags.size() <= 5;
           
         allow update: if isOwner(userId)
           && request.resource.data.id == resource.data.id
           && request.resource.data.origem == resource.data.origem
-          && request.resource.data.titulo.size() <= 100
+          && request.resource.data.titulo.size() <= 255
           && request.resource.data.ano >= 1900 && request.resource.data.ano <= 2026
           && request.resource.data.tags.size() <= 5;
       }

--- a/lib/features/auth/presentation/profile_view.dart
+++ b/lib/features/auth/presentation/profile_view.dart
@@ -5,11 +5,18 @@ import 'package:ifdex/features/auth/widgets/google_sign_in_button.dart';
 import 'package:ifdex/shared/theme/app_theme.dart';
 import 'package:ifdex/shared/widgets/app_text.dart';
 
-class ProfileView extends ConsumerWidget {
+class ProfileView extends ConsumerStatefulWidget {
   const ProfileView({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ProfileView> createState() => _ProfileViewState();
+}
+
+class _ProfileViewState extends ConsumerState<ProfileView> {
+  bool _isLoading = false;
+
+  @override
+  Widget build(BuildContext context) {
     final authState = ref.watch(authViewModelProvider);
 
     return Scaffold(
@@ -46,31 +53,39 @@ class ProfileView extends ConsumerWidget {
                     color: AppColors.textSecondary,
                   ),
                   const SizedBox(height: 32),
-                  GoogleSignInButton(
-                    onPressed: () async {
-                      try {
-                        await ref
-                            .read(authViewModelProvider.notifier)
-                            .linkWithGoogle();
-                      } catch (e) {
-                        if (context.mounted) {
-                          final erro = e.toString();
-                          if (erro.contains('popup_closed')) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('Login com Google cancelado.'),
-                                duration: Duration(seconds: 2),
-                              ),
-                            );
-                          } else {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('Erro: $erro')),
-                            );
-                          }
-                        }
-                      }
-                    },
-                  ),
+                  _isLoading
+                      ? const CircularProgressIndicator()
+                      : GoogleSignInButton(
+                          onPressed: () async {
+                            if (_isLoading) return;
+                            setState(() => _isLoading = true);
+                            try {
+                              await ref
+                                  .read(authViewModelProvider.notifier)
+                                  .linkWithGoogle();
+                            } catch (e) {
+                              if (context.mounted) {
+                                final erro = e.toString();
+                                if (erro.contains('popup_closed')) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text(
+                                        'Login com Google cancelado.',
+                                      ),
+                                      duration: Duration(seconds: 2),
+                                    ),
+                                  );
+                                } else {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text('Erro: $erro')),
+                                  );
+                                }
+                              }
+                            } finally {
+                              if (mounted) setState(() => _isLoading = false);
+                            }
+                          },
+                        ),
                 ],
               ),
             );
@@ -112,12 +127,22 @@ class ProfileView extends ConsumerWidget {
                 SizedBox(
                   width: double.infinity,
                   child: ElevatedButton(
-                    onPressed: () async {
-                      await ref.read(authViewModelProvider.notifier).signOut();
-                      if (context.mounted) {
-                        Navigator.of(context).pop();
-                      }
-                    },
+                    onPressed: _isLoading
+                        ? null
+                        : () async {
+                            if (_isLoading) return;
+                            setState(() => _isLoading = true);
+                            try {
+                              await ref
+                                  .read(authViewModelProvider.notifier)
+                                  .signOut();
+                              if (context.mounted) {
+                                Navigator.of(context).pop();
+                              }
+                            } finally {
+                              if (mounted) setState(() => _isLoading = false);
+                            }
+                          },
                     style: ElevatedButton.styleFrom(
                       backgroundColor: AppColors.error.withValues(alpha: 0.1),
                       foregroundColor: AppColors.error,
@@ -127,12 +152,20 @@ class ProfileView extends ConsumerWidget {
                         borderRadius: BorderRadius.circular(14),
                       ),
                     ),
-                    child: const AppText(
-                      'Sair da Conta',
-                      fontSize: 14,
-                      fontWeight: FontWeight.bold,
-                      color: AppColors.error,
-                    ),
+                    child: _isLoading
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              color: AppColors.error,
+                            ),
+                          )
+                        : const AppText(
+                            'Sair da Conta',
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                            color: AppColors.error,
+                          ),
                   ),
                 ),
               ],

--- a/lib/features/certificados/models/certificado.dart
+++ b/lib/features/certificados/models/certificado.dart
@@ -62,10 +62,10 @@ class Certificado {
     required int notaRelevancia,
   }) {
     // 1. Validação de Título
-    if (titulo.trim().isEmpty || titulo.length > 100) {
+    if (titulo.trim().isEmpty || titulo.length > 255) {
       throw ArgumentError(
         'O título é obrigatório e deve ter '
-        'no máximo 100 caracteres.',
+        'no máximo 255 caracteres.',
       );
     }
 

--- a/lib/features/certificados/presentation/certificado_form_view.dart
+++ b/lib/features/certificados/presentation/certificado_form_view.dart
@@ -130,8 +130,13 @@ class _CertificadoFormViewState extends ConsumerState<CertificadoFormView> {
     });
   }
 
+  bool _isLoading = false;
+
   Future<void> _salvar() async {
+    if (_isLoading) return;
     if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
 
     final c = _certificadoOriginal;
     final tags = _tagsCtrl.text
@@ -213,6 +218,10 @@ class _CertificadoFormViewState extends ConsumerState<CertificadoFormView> {
           duration: const Duration(seconds: 5),
         ),
       );
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
   }
 
@@ -531,10 +540,19 @@ class _CertificadoFormViewState extends ConsumerState<CertificadoFormView> {
             SizedBox(
               width: double.infinity,
               child: FilledButton.icon(
-                onPressed: _salvar,
-                icon: const Icon(Icons.save),
+                onPressed: _isLoading ? null : _salvar,
+                icon: _isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: AppColors.textOnPrimary,
+                        ),
+                      )
+                    : const Icon(Icons.save),
                 label: AppText(
-                  labelSalvar,
+                  _isLoading ? 'Salvando...' : labelSalvar,
                   color: AppColors.textOnPrimary,
                   fontWeight: FontWeight.w600,
                 ),

--- a/lib/features/certificados/presentation/certificado_form_view.dart
+++ b/lib/features/certificados/presentation/certificado_form_view.dart
@@ -303,8 +303,8 @@ class _CertificadoFormViewState extends ConsumerState<CertificadoFormView> {
                   if (v == null || v.trim().isEmpty) {
                     return 'Obrigatório';
                   }
-                  if (v.length > 100) {
-                    return 'Máx. 100 caracteres';
+                  if (v.length > 255) {
+                    return 'Máx. 255 caracteres';
                   }
                   return null;
                 },

--- a/lib/features/certificados/presentation/certificados_view_model.dart
+++ b/lib/features/certificados/presentation/certificados_view_model.dart
@@ -3,17 +3,128 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:ifdex/features/certificados/data/certificado_repository.dart';
 import 'package:ifdex/features/certificados/models/certificado.dart';
 import 'package:ifdex/shared/providers/busca_providers.dart';
+import 'package:ifdex/shared/providers/ordenacao_providers.dart';
+import 'package:ifdex/shared/models/ordenacao_enum.dart';
+import 'package:ifdex/shared/models/filtros_globais.dart';
 
 part 'certificados_view_model.g.dart';
 
 @riverpod
 class FiltroCertificados extends _$FiltroCertificados {
   @override
-  String build() => 'todos';
+  FiltrosGlobais build() => const FiltrosGlobais();
 
-  void setFiltro(String filtro) {
-    state = filtro;
+  void toggleInstituicao(String inst) {
+    final newSet = Set<String>.from(state.instituicoesSelecionadas);
+    if (newSet.contains(inst)) {
+      newSet.remove(inst);
+    } else {
+      newSet.add(inst);
+    }
+    state = state.copyWith(instituicoesSelecionadas: newSet);
   }
+
+  void toggleEstrela(int estrela) {
+    final newSet = Set<int>.from(state.estrelasSelecionadas);
+    if (newSet.contains(estrela)) {
+      newSet.remove(estrela);
+    } else {
+      newSet.add(estrela);
+    }
+    state = state.copyWith(estrelasSelecionadas: newSet);
+  }
+
+  void setAno(int? min, int? max) {
+    state = state.copyWith(minAno: min, maxAno: max);
+  }
+
+  void toggleTipo(String tipo) {
+    final newSet = Set<String>.from(state.tiposSelecionados);
+    if (newSet.contains(tipo)) {
+      newSet.remove(tipo);
+    } else {
+      newSet.add(tipo);
+    }
+    state = state.copyWith(tiposSelecionados: newSet);
+  }
+
+  void toggleTag(String tag) {
+    final newSet = Set<String>.from(state.tagsSelecionadas);
+    if (newSet.contains(tag)) {
+      newSet.remove(tag);
+    } else {
+      newSet.add(tag);
+    }
+    state = state.copyWith(tagsSelecionadas: newSet);
+  }
+
+  void setCargaHoraria(int min, int max) {
+    state = state.copyWith(minCargaHoraria: min, maxCargaHoraria: max);
+  }
+
+  void setOrigem(String origem) {
+    state = state.copyWith(origemSelecionada: origem);
+  }
+
+  void limparFiltros() {
+    state = const FiltrosGlobais();
+  }
+}
+
+@riverpod
+Set<String> instituicoesAtivas(InstituicoesAtivasRef ref) {
+  final asyncCertificados = ref.watch(certificadosViewModelProvider);
+  if (asyncCertificados is! AsyncData) {
+    return const {};
+  }
+
+  final lista = asyncCertificados.requireValue;
+  final instituicoes = <String>{};
+
+  for (final c in lista) {
+    if (c.instituicao.trim().isNotEmpty) {
+      instituicoes.add(c.instituicao.trim());
+    }
+  }
+
+  return instituicoes;
+}
+
+@riverpod
+Set<int> anosAtivos(AnosAtivosRef ref) {
+  final asyncCertificados = ref.watch(certificadosViewModelProvider);
+  if (asyncCertificados is! AsyncData) return const {};
+  final lista = asyncCertificados.requireValue;
+  final anos = lista.map((c) => c.ano).toSet();
+  // Ordenar decrescente
+  final sorted = anos.toList()..sort((a, b) => b.compareTo(a));
+  return sorted.toSet();
+}
+
+@riverpod
+Set<String> tiposAtivos(TiposAtivosRef ref) {
+  final asyncCertificados = ref.watch(certificadosViewModelProvider);
+  if (asyncCertificados is! AsyncData) return const {};
+  final lista = asyncCertificados.requireValue;
+  final tipos = lista
+      .map((c) => c.tipoDescricao.trim())
+      .where((t) => t.isNotEmpty)
+      .toSet();
+  final sorted = tipos.toList()..sort();
+  return sorted.toSet();
+}
+
+@riverpod
+Set<String> tagsAtivas(TagsAtivasRef ref) {
+  final asyncCertificados = ref.watch(certificadosViewModelProvider);
+  if (asyncCertificados is! AsyncData) return const {};
+  final lista = asyncCertificados.requireValue;
+  final tags = <String>{};
+  for (final c in lista) {
+    tags.addAll(c.tags.map((t) => t.trim()).where((t) => t.isNotEmpty));
+  }
+  final sorted = tags.toList()..sort();
+  return sorted.toSet();
 }
 
 @riverpod
@@ -62,12 +173,65 @@ List<Certificado> certificadosFiltrados(CertificadosFiltradosRef ref) {
   }
   var lista = asyncCertificados.requireValue;
 
-  // Filtro Tipo
-  final filtroTipo = ref.watch(filtroCertificadosProvider);
-  if (filtroTipo == 'oficial') {
+  // Filtros Avançados
+  final filtros = ref.watch(filtroCertificadosProvider);
+
+  // 1. Origem
+  if (filtros.origemSelecionada == 'oficial') {
     lista = lista.where((c) => c.origem == Origem.sispubli).toList();
-  } else if (filtroTipo == 'manual') {
+  } else if (filtros.origemSelecionada == 'manual') {
     lista = lista.where((c) => c.origem == Origem.manual).toList();
+  }
+
+  // 2. Instituições
+  if (filtros.instituicoesSelecionadas.isNotEmpty) {
+    lista = lista
+        .where(
+          (c) =>
+              filtros.instituicoesSelecionadas.contains(c.instituicao.trim()),
+        )
+        .toList();
+  }
+
+  // 3. Estrelas
+  if (filtros.estrelasSelecionadas.isNotEmpty) {
+    lista = lista
+        .where((c) => filtros.estrelasSelecionadas.contains(c.notaRelevancia))
+        .toList();
+  }
+
+  // 4. Carga Horária
+  if (filtros.minCargaHoraria > 0 || filtros.maxCargaHoraria < 5000) {
+    lista = lista.where((c) {
+      final ch = c.cargaHoraria ?? 0;
+      return ch >= filtros.minCargaHoraria && ch <= filtros.maxCargaHoraria;
+    }).toList();
+  }
+
+  // 5. Ano
+  if (filtros.minAno != null) {
+    lista = lista.where((c) => c.ano >= filtros.minAno!).toList();
+  }
+  if (filtros.maxAno != null) {
+    lista = lista.where((c) => c.ano <= filtros.maxAno!).toList();
+  }
+
+  // 6. Tipo
+  if (filtros.tiposSelecionados.isNotEmpty) {
+    lista = lista
+        .where(
+          (c) => filtros.tiposSelecionados.contains(c.tipoDescricao.trim()),
+        )
+        .toList();
+  }
+
+  // 7. Tags
+  if (filtros.tagsSelecionadas.isNotEmpty) {
+    lista = lista
+        .where(
+          (c) => c.tags.any((t) => filtros.tagsSelecionadas.contains(t.trim())),
+        )
+        .toList();
   }
 
   // Busca Texto (Case-insensitive e Trim garantidos na origem do Debounce)
@@ -82,6 +246,27 @@ List<Certificado> certificadosFiltrados(CertificadosFiltradosRef ref) {
       return titulo || inst || tipo || tag;
     }).toList();
   }
+
+  // Ordenação
+  final ordem = ref.watch(ordenacaoHomeStateProvider);
+  lista.sort((a, b) {
+    switch (ordem) {
+      case OrdenacaoHome.anoDesc:
+        return b.ano.compareTo(a.ano);
+      case OrdenacaoHome.anoAsc:
+        return a.ano.compareTo(b.ano);
+      case OrdenacaoHome.relevanciaDesc:
+        return b.notaRelevancia.compareTo(a.notaRelevancia);
+      case OrdenacaoHome.cargaHorariaDesc:
+        final chA = a.cargaHoraria ?? 0;
+        final chB = b.cargaHoraria ?? 0;
+        return chB.compareTo(chA);
+      case OrdenacaoHome.tituloAsc:
+        return a.titulo.toLowerCase().compareTo(b.titulo.toLowerCase());
+      case OrdenacaoHome.tituloDesc:
+        return b.titulo.toLowerCase().compareTo(a.titulo.toLowerCase());
+    }
+  });
 
   // Resultado Final
   return lista;

--- a/lib/features/certificados/presentation/certificados_view_model.dart
+++ b/lib/features/certificados/presentation/certificados_view_model.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:ifdex/features/certificados/data/certificado_repository.dart';
 import 'package:ifdex/features/certificados/models/certificado.dart';
+import 'package:ifdex/shared/providers/busca_providers.dart';
 
 part 'certificados_view_model.g.dart';
 
@@ -54,21 +55,35 @@ class CertificadosViewModel extends _$CertificadosViewModel {
 
 @riverpod
 List<Certificado> certificadosFiltrados(CertificadosFiltradosRef ref) {
+  // Lista Original
   final asyncCertificados = ref.watch(certificadosViewModelProvider);
-  final filtro = ref.watch(filtroCertificadosProvider);
-
   if (asyncCertificados is! AsyncData) {
     return const [];
   }
+  var lista = asyncCertificados.requireValue;
 
-  final lista = asyncCertificados.requireValue;
+  // Filtro Tipo
+  final filtroTipo = ref.watch(filtroCertificadosProvider);
+  if (filtroTipo == 'oficial') {
+    lista = lista.where((c) => c.origem == Origem.sispubli).toList();
+  } else if (filtroTipo == 'manual') {
+    lista = lista.where((c) => c.origem == Origem.manual).toList();
+  }
 
-  if (filtro == 'oficial') {
-    return lista.where((c) => c.origem == Origem.sispubli).toList();
+  // Busca Texto (Case-insensitive e Trim garantidos na origem do Debounce)
+  final query = ref.watch(buscaHomeDebouncedProvider);
+  if (query.isNotEmpty) {
+    lista = lista.where((c) {
+      final titulo = c.titulo.toLowerCase().contains(query);
+      final inst = c.instituicao.toLowerCase().contains(query);
+      final tipo = c.tipoDescricao.toLowerCase().contains(query);
+      final tag = c.tags.any((t) => t.toLowerCase().contains(query));
+
+      return titulo || inst || tipo || tag;
+    }).toList();
   }
-  if (filtro == 'manual') {
-    return lista.where((c) => c.origem == Origem.manual).toList();
-  }
+
+  // Resultado Final
   return lista;
 }
 

--- a/lib/features/certificados/presentation/certificados_view_model.g.dart
+++ b/lib/features/certificados/presentation/certificados_view_model.g.dart
@@ -7,7 +7,7 @@ part of 'certificados_view_model.dart';
 // **************************************************************************
 
 String _$certificadosFiltradosHash() =>
-    r'5fa9897973d724f64b05c7eb095feab140958594';
+    r'a762527f4e9025b66ec2661612c38cf0971c360b';
 
 /// See also [certificadosFiltrados].
 @ProviderFor(certificadosFiltrados)

--- a/lib/features/certificados/presentation/certificados_view_model.g.dart
+++ b/lib/features/certificados/presentation/certificados_view_model.g.dart
@@ -6,8 +6,77 @@ part of 'certificados_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$instituicoesAtivasHash() =>
+    r'18a3ca577b63365f990ac2f3ecbb594649895f16';
+
+/// See also [instituicoesAtivas].
+@ProviderFor(instituicoesAtivas)
+final instituicoesAtivasProvider = AutoDisposeProvider<Set<String>>.internal(
+  instituicoesAtivas,
+  name: r'instituicoesAtivasProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$instituicoesAtivasHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef InstituicoesAtivasRef = AutoDisposeProviderRef<Set<String>>;
+String _$anosAtivosHash() => r'd90acd1aa4ce079775e7da344eeac48f1990dc7e';
+
+/// See also [anosAtivos].
+@ProviderFor(anosAtivos)
+final anosAtivosProvider = AutoDisposeProvider<Set<int>>.internal(
+  anosAtivos,
+  name: r'anosAtivosProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$anosAtivosHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AnosAtivosRef = AutoDisposeProviderRef<Set<int>>;
+String _$tiposAtivosHash() => r'a2d9b56185d75fbd6815f7daef5b844a7d8bbd85';
+
+/// See also [tiposAtivos].
+@ProviderFor(tiposAtivos)
+final tiposAtivosProvider = AutoDisposeProvider<Set<String>>.internal(
+  tiposAtivos,
+  name: r'tiposAtivosProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$tiposAtivosHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef TiposAtivosRef = AutoDisposeProviderRef<Set<String>>;
+String _$tagsAtivasHash() => r'b9d3882d34ac31713305f866c408086841512393';
+
+/// See also [tagsAtivas].
+@ProviderFor(tagsAtivas)
+final tagsAtivasProvider = AutoDisposeProvider<Set<String>>.internal(
+  tagsAtivas,
+  name: r'tagsAtivasProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$tagsAtivasHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef TagsAtivasRef = AutoDisposeProviderRef<Set<String>>;
 String _$certificadosFiltradosHash() =>
-    r'a762527f4e9025b66ec2661612c38cf0971c360b';
+    r'3ab391f4b13e6201f40d512f5e4bf7c2b205160a';
 
 /// See also [certificadosFiltrados].
 @ProviderFor(certificadosFiltrados)
@@ -167,12 +236,12 @@ class _CertificadoPorIdProviderElement
 }
 
 String _$filtroCertificadosHash() =>
-    r'c2df54e989ddd7053f0fabed0e472d09bdf83094';
+    r'034e9e45a721af74a14f1092228caca5004d1364';
 
 /// See also [FiltroCertificados].
 @ProviderFor(FiltroCertificados)
 final filtroCertificadosProvider =
-    AutoDisposeNotifierProvider<FiltroCertificados, String>.internal(
+    AutoDisposeNotifierProvider<FiltroCertificados, FiltrosGlobais>.internal(
       FiltroCertificados.new,
       name: r'filtroCertificadosProvider',
       debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -182,7 +251,7 @@ final filtroCertificadosProvider =
       allTransitiveDependencies: null,
     );
 
-typedef _$FiltroCertificados = AutoDisposeNotifier<String>;
+typedef _$FiltroCertificados = AutoDisposeNotifier<FiltrosGlobais>;
 String _$certificadosViewModelHash() =>
     r'9a0a8967d1fc0410c7644767f736566261860a66';
 

--- a/lib/features/home/presentation/home_mobile_view.dart
+++ b/lib/features/home/presentation/home_mobile_view.dart
@@ -13,6 +13,7 @@ import 'package:ifdex/shared/widgets/app_error_state.dart';
 import 'package:ifdex/shared/widgets/app_empty_state.dart';
 import 'package:ifdex/shared/widgets/app_search_bar.dart';
 import 'package:ifdex/shared/providers/busca_providers.dart';
+import 'package:ifdex/shared/widgets/app_filtros_bottom_sheet.dart';
 
 class HomeMobileView extends ConsumerWidget {
   const HomeMobileView({super.key});
@@ -80,8 +81,6 @@ class _BarraFiltros extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final filtroAtual = ref.watch(filtroCertificadosProvider);
-
     return Container(
       color: Colors.white,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -95,39 +94,21 @@ class _BarraFiltros extends ConsumerWidget {
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
               ),
-              DropdownButtonHideUnderline(
-                child: DropdownButton<String>(
-                  value: filtroAtual,
-                  icon: const Icon(
-                    Icons.filter_list,
-                    color: AppColors.primary,
-                    size: 20,
-                  ),
-                  style: const TextStyle(
-                    color: AppColors.primary,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 14,
-                    fontFamily: 'Inter',
-                  ),
-                  items: const [
-                    DropdownMenuItem(value: 'todos', child: Text('Todos')),
-                    DropdownMenuItem(
-                      value: 'oficial',
-                      child: Text('Oficiais (IFS)'),
-                    ),
-                    DropdownMenuItem(
-                      value: 'manual',
-                      child: Text('Adicionados'),
-                    ),
-                  ],
-                  onChanged: (novo) {
-                    if (novo != null) {
-                      ref
-                          .read(filtroCertificadosProvider.notifier)
-                          .setFiltro(novo);
-                    }
-                  },
+              IconButton(
+                icon: const Icon(
+                  Icons.tune,
+                  color: AppColors.primary,
+                  size: 20,
                 ),
+                tooltip: 'Filtrar e Ordenar',
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    backgroundColor: Colors.transparent,
+                    builder: (_) => const AppFiltrosBottomSheet(),
+                  );
+                },
               ),
             ],
           ),

--- a/lib/features/home/presentation/home_mobile_view.dart
+++ b/lib/features/home/presentation/home_mobile_view.dart
@@ -11,6 +11,8 @@ import 'package:ifdex/features/certificados/presentation/certificado_details_vie
 import 'package:ifdex/shared/widgets/app_loading_state.dart';
 import 'package:ifdex/shared/widgets/app_error_state.dart';
 import 'package:ifdex/shared/widgets/app_empty_state.dart';
+import 'package:ifdex/shared/widgets/app_search_bar.dart';
+import 'package:ifdex/shared/providers/busca_providers.dart';
 
 class HomeMobileView extends ConsumerWidget {
   const HomeMobileView({super.key});
@@ -83,42 +85,58 @@ class _BarraFiltros extends ConsumerWidget {
     return Container(
       color: Colors.white,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Column(
         children: [
-          const AppText(
-            'Meus Certificados',
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-          ),
-          DropdownButtonHideUnderline(
-            child: DropdownButton<String>(
-              value: filtroAtual,
-              icon: const Icon(
-                Icons.filter_list,
-                color: AppColors.primary,
-                size: 20,
-              ),
-              style: const TextStyle(
-                color: AppColors.primary,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const AppText(
+                'Meus Certificados',
+                fontSize: 16,
                 fontWeight: FontWeight.w600,
-                fontSize: 14,
-                fontFamily: 'Inter',
               ),
-              items: const [
-                DropdownMenuItem(value: 'todos', child: Text('Todos')),
-                DropdownMenuItem(
-                  value: 'oficial',
-                  child: Text('Oficiais (IFS)'),
+              DropdownButtonHideUnderline(
+                child: DropdownButton<String>(
+                  value: filtroAtual,
+                  icon: const Icon(
+                    Icons.filter_list,
+                    color: AppColors.primary,
+                    size: 20,
+                  ),
+                  style: const TextStyle(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    fontFamily: 'Inter',
+                  ),
+                  items: const [
+                    DropdownMenuItem(value: 'todos', child: Text('Todos')),
+                    DropdownMenuItem(
+                      value: 'oficial',
+                      child: Text('Oficiais (IFS)'),
+                    ),
+                    DropdownMenuItem(
+                      value: 'manual',
+                      child: Text('Adicionados'),
+                    ),
+                  ],
+                  onChanged: (novo) {
+                    if (novo != null) {
+                      ref
+                          .read(filtroCertificadosProvider.notifier)
+                          .setFiltro(novo);
+                    }
+                  },
                 ),
-                DropdownMenuItem(value: 'manual', child: Text('Adicionados')),
-              ],
-              onChanged: (novo) {
-                if (novo != null) {
-                  ref.read(filtroCertificadosProvider.notifier).setFiltro(novo);
-                }
-              },
-            ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          AppSearchBar(
+            initialValue: ref.read(buscaHomeProvider),
+            onChanged: (val) {
+              ref.read(buscaHomeProvider.notifier).setQuery(val);
+            },
           ),
         ],
       ),

--- a/lib/features/home/presentation/home_view.dart
+++ b/lib/features/home/presentation/home_view.dart
@@ -194,7 +194,7 @@ class _MiniAction extends StatelessWidget {
         ),
         const SizedBox(width: 12),
         FloatingActionButton.small(
-          heroTag: label,
+          heroTag: null,
           onPressed: onTap,
           backgroundColor: AppColors.surface,
           foregroundColor: AppColors.primary,

--- a/lib/features/home/presentation/home_web_view.dart
+++ b/lib/features/home/presentation/home_web_view.dart
@@ -16,6 +16,8 @@ import 'package:ifdex/features/sispubli/presentation/sispubli_import_view.dart';
 import 'package:ifdex/shared/widgets/app_loading_state.dart';
 import 'package:ifdex/shared/widgets/app_error_state.dart';
 import 'package:ifdex/shared/widgets/app_empty_state.dart';
+import 'package:ifdex/shared/widgets/app_search_bar.dart';
+import 'package:ifdex/shared/providers/busca_providers.dart';
 
 class HomeWebView extends ConsumerWidget {
   const HomeWebView({super.key});
@@ -220,6 +222,16 @@ class _TopBar extends ConsumerWidget {
         children: [
           AppText.headline('Dashboard Acadêmico'),
           const Spacer(),
+          SizedBox(
+            width: 300,
+            child: AppSearchBar(
+              initialValue: ref.read(buscaHomeProvider),
+              onChanged: (val) {
+                ref.read(buscaHomeProvider.notifier).setQuery(val);
+              },
+            ),
+          ),
+          const SizedBox(width: 16),
           PopupMenuButton<String>(
             onSelected: (novo) =>
                 ref.read(filtroCertificadosProvider.notifier).setFiltro(novo),

--- a/lib/features/home/presentation/home_web_view.dart
+++ b/lib/features/home/presentation/home_web_view.dart
@@ -18,6 +18,7 @@ import 'package:ifdex/shared/widgets/app_error_state.dart';
 import 'package:ifdex/shared/widgets/app_empty_state.dart';
 import 'package:ifdex/shared/widgets/app_search_bar.dart';
 import 'package:ifdex/shared/providers/busca_providers.dart';
+import 'package:ifdex/shared/widgets/app_filtros_bottom_sheet.dart';
 
 class HomeWebView extends ConsumerWidget {
   const HomeWebView({super.key});
@@ -196,21 +197,8 @@ class _XpSidebarCard extends StatelessWidget {
 class _TopBar extends ConsumerWidget {
   const _TopBar();
 
-  String _labelFiltro(String filtroAtual) {
-    switch (filtroAtual) {
-      case 'oficial':
-        return 'Oficiais';
-      case 'manual':
-        return 'Manuais';
-      default:
-        return 'Todos';
-    }
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final filtroAtual = ref.watch(filtroCertificadosProvider);
-
     return Container(
       height: 80,
       padding: const EdgeInsets.symmetric(horizontal: 32),
@@ -232,37 +220,22 @@ class _TopBar extends ConsumerWidget {
             ),
           ),
           const SizedBox(width: 16),
-          PopupMenuButton<String>(
-            onSelected: (novo) =>
-                ref.read(filtroCertificadosProvider.notifier).setFiltro(novo),
-            itemBuilder: (_) => [
-              const PopupMenuItem(value: 'todos', child: AppText('Todos')),
-              const PopupMenuItem(value: 'oficial', child: AppText('Oficiais')),
-              const PopupMenuItem(value: 'manual', child: AppText('Manuais')),
-            ],
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              decoration: BoxDecoration(
-                color: AppColors.background,
-                borderRadius: BorderRadius.circular(14),
-                border: Border.all(color: AppColors.border),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(
-                    Icons.filter_alt_outlined,
-                    size: 18,
-                    color: AppColors.textSecondary,
+          IconButton(
+            onPressed: () {
+              showDialog<void>(
+                context: context,
+                builder: (_) => Dialog(
+                  backgroundColor: Colors.transparent,
+                  insetPadding: const EdgeInsets.all(24),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 450),
+                    child: const AppFiltrosBottomSheet(),
                   ),
-                  const SizedBox(width: 6),
-                  AppText.label(
-                    _labelFiltro(filtroAtual),
-                    color: AppColors.textPrimary,
-                  ),
-                ],
-              ),
-            ),
+                ),
+              );
+            },
+            tooltip: 'Filtrar e Ordenar',
+            icon: const Icon(Icons.tune, color: AppColors.primary, size: 24),
           ),
           const SizedBox(width: 12),
           ElevatedButton.icon(

--- a/lib/features/sispubli/models/filtros_sispubli.dart
+++ b/lib/features/sispubli/models/filtros_sispubli.dart
@@ -1,0 +1,26 @@
+class FiltrosSispubli {
+  final int? minAno;
+  final int? maxAno;
+  final Set<String> tiposSelecionados;
+
+  const FiltrosSispubli({
+    this.minAno,
+    this.maxAno,
+    this.tiposSelecionados = const {},
+  });
+
+  FiltrosSispubli copyWith({
+    int? minAno,
+    int? maxAno,
+    Set<String>? tiposSelecionados,
+  }) {
+    return FiltrosSispubli(
+      minAno: minAno ?? this.minAno,
+      maxAno: maxAno ?? this.maxAno,
+      tiposSelecionados: tiposSelecionados ?? this.tiposSelecionados,
+    );
+  }
+
+  bool get isEmpty =>
+      minAno == null && maxAno == null && tiposSelecionados.isEmpty;
+}

--- a/lib/features/sispubli/presentation/sispubli_import_view_model.dart
+++ b/lib/features/sispubli/presentation/sispubli_import_view_model.dart
@@ -104,7 +104,12 @@ class SispubliImportViewModel extends _$SispubliImportViewModel {
             cert.uploadDocumento = bytes;
             await repo.adicionar(cert, fileName: '${cert.id}.pdf');
             importados++;
-          } catch (_) {
+          } catch (e) {
+            // ignore: avoid_print
+            print(
+              '[SispubliImport] Erro ao baixar ou fazer upload do PDF '
+              '("${dto.titulo}"): $e',
+            );
             // PDF falhou — salvar só metadados
             await repo.adicionar(cert);
             semDocumento++;
@@ -114,7 +119,12 @@ class SispubliImportViewModel extends _$SispubliImportViewModel {
           await repo.adicionar(cert);
           semDocumento++;
         }
-      } catch (_) {
+      } catch (e, st) {
+        // ignore: avoid_print
+        print(
+          '[SispubliImport] ERRO TOTAL (rejeição do certificado): '
+          '["${dto.titulo}"] -> $e\n$st',
+        );
         erros++;
       }
 

--- a/lib/features/sispubli/presentation/sispubli_providers.dart
+++ b/lib/features/sispubli/presentation/sispubli_providers.dart
@@ -1,48 +1,133 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:ifdex/features/sispubli/data/sispubli_datasource.dart';
 import 'package:ifdex/features/certificados/presentation/certificados_view_model.dart';
 import 'package:ifdex/features/sispubli/presentation/sispubli_import_view_model.dart';
+import 'package:ifdex/features/sispubli/models/filtros_sispubli.dart';
 import 'package:ifdex/shared/providers/busca_providers.dart';
+import 'package:ifdex/shared/providers/ordenacao_providers.dart';
+import 'package:ifdex/shared/models/ordenacao_enum.dart';
+
+part 'sispubli_providers.g.dart';
+
+@riverpod
+class FiltroSispubliNotifier extends _$FiltroSispubliNotifier {
+  @override
+  FiltrosSispubli build() => const FiltrosSispubli();
+
+  void setAno(int? min, int? max) {
+    state = state.copyWith(minAno: min, maxAno: max);
+  }
+
+  void toggleTipo(String tipo) {
+    final newSet = Set<String>.from(state.tiposSelecionados);
+    if (newSet.contains(tipo)) {
+      newSet.remove(tipo);
+    } else {
+      newSet.add(tipo);
+    }
+    state = state.copyWith(tiposSelecionados: newSet);
+  }
+
+  void limparFiltros() {
+    state = const FiltrosSispubli();
+  }
+}
+
+@riverpod
+Set<int> anosAtivosSispubli(AnosAtivosSispubliRef ref) {
+  final importStateAsync = ref.watch(sispubliImportViewModelProvider);
+  if (importStateAsync.value == null) return const {};
+  final dtos = importStateAsync.value!.certificadosNovos;
+  final anos = dtos.map((c) => c.ano).toSet();
+  final sorted = anos.toList()..sort((a, b) => b.compareTo(a));
+  return sorted.toSet();
+}
+
+@riverpod
+Set<String> tiposAtivosSispubli(TiposAtivosSispubliRef ref) {
+  final importStateAsync = ref.watch(sispubliImportViewModelProvider);
+  if (importStateAsync.value == null) return const {};
+  final dtos = importStateAsync.value!.certificadosNovos;
+  final tipos = dtos
+      .map((c) => c.tipoDescricao.trim())
+      .where((t) => t.isNotEmpty)
+      .toSet();
+  final sorted = tipos.toList()..sort();
+  return sorted.toSet();
+}
 
 /// Provider Computado que atua como Filtro Inteligente.
 /// Observa o estado do fetch da API e os dados locais do usuário,
 /// retornando apenas os certificados do Sispubli que ainda não
 /// foram salvos no cofre do IFdex.
-final certificadosSispubliDisponiveisProvider =
-    Provider.autoDispose<List<SispubliCertificadoDto>>((ref) {
-      // 1. Observa o resultado do fetch
-      final importStateAsync = ref.watch(sispubliImportViewModelProvider);
+@riverpod
+List<SispubliCertificadoDto> certificadosSispubliDisponiveis(
+  CertificadosSispubliDisponiveisRef ref,
+) {
+  // 1. Observa o resultado do fetch
+  final importStateAsync = ref.watch(sispubliImportViewModelProvider);
 
-      if (importStateAsync.value == null) {
-        return const [];
-      }
+  if (importStateAsync.value == null) {
+    return const [];
+  }
 
-      final dtosDaApi = importStateAsync.value!.certificadosNovos;
+  final dtosDaApi = importStateAsync.value!.certificadosNovos;
 
-      // 2. Observa a base de dados em tempo real
-      final certificadosLocaisAsync = ref.watch(certificadosViewModelProvider);
+  // 2. Observa a base de dados em tempo real
+  final certificadosLocaisAsync = ref.watch(certificadosViewModelProvider);
 
-      final idsLocais = <String>{};
-      if (certificadosLocaisAsync is AsyncData) {
-        for (final cert in certificadosLocaisAsync.requireValue) {
-          idsLocais.add(cert.id);
-        }
-      }
+  final idsLocais = <String>{};
+  if (certificadosLocaisAsync is AsyncData) {
+    for (final cert in certificadosLocaisAsync.requireValue) {
+      idsLocais.add(cert.id);
+    }
+  }
 
-      // 3. Aplica o filtro de deduplicação reativamente
-      var lista = dtosDaApi
-          .where((dto) => !idsLocais.contains(dto.idUnico))
-          .toList();
+  // 3. Aplica o filtro de deduplicação reativamente
+  var lista = dtosDaApi
+      .where((dto) => !idsLocais.contains(dto.idUnico))
+      .toList();
 
-      // 4. Busca Texto (Case-insensitive e Trim garantidos no Debounce)
-      final query = ref.watch(buscaSispubliDebouncedProvider);
-      if (query.isNotEmpty) {
-        lista = lista.where((dto) {
-          final titulo = dto.titulo.toLowerCase().contains(query);
-          final tipo = dto.tipoDescricao.toLowerCase().contains(query);
-          return titulo || tipo;
-        }).toList();
-      }
+  // 4. Aplica os filtros avançados Sispubli
+  final filtros = ref.watch(filtroSispubliNotifierProvider);
+  if (filtros.minAno != null) {
+    lista = lista.where((c) => c.ano >= filtros.minAno!).toList();
+  }
+  if (filtros.maxAno != null) {
+    lista = lista.where((c) => c.ano <= filtros.maxAno!).toList();
+  }
+  if (filtros.tiposSelecionados.isNotEmpty) {
+    lista = lista
+        .where(
+          (c) => filtros.tiposSelecionados.contains(c.tipoDescricao.trim()),
+        )
+        .toList();
+  }
 
-      return lista;
-    });
+  // 5. Busca Texto (Case-insensitive e Trim garantidos no Debounce)
+  final query = ref.watch(buscaSispubliDebouncedProvider);
+  if (query.isNotEmpty) {
+    lista = lista.where((dto) {
+      final titulo = dto.titulo.toLowerCase().contains(query);
+      final tipo = dto.tipoDescricao.toLowerCase().contains(query);
+      return titulo || tipo;
+    }).toList();
+  }
+
+  // 6. Ordenação
+  final ordem = ref.watch(ordenacaoSispubliStateProvider);
+  lista.sort((a, b) {
+    switch (ordem) {
+      case OrdenacaoSispubli.anoDesc:
+        return b.ano.compareTo(a.ano);
+      case OrdenacaoSispubli.anoAsc:
+        return a.ano.compareTo(b.ano);
+      case OrdenacaoSispubli.tituloAsc:
+        return a.titulo.toLowerCase().compareTo(b.titulo.toLowerCase());
+      case OrdenacaoSispubli.tituloDesc:
+        return b.titulo.toLowerCase().compareTo(a.titulo.toLowerCase());
+    }
+  });
+
+  return lista;
+}

--- a/lib/features/sispubli/presentation/sispubli_providers.dart
+++ b/lib/features/sispubli/presentation/sispubli_providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ifdex/features/sispubli/data/sispubli_datasource.dart';
 import 'package:ifdex/features/certificados/presentation/certificados_view_model.dart';
 import 'package:ifdex/features/sispubli/presentation/sispubli_import_view_model.dart';
+import 'package:ifdex/shared/providers/busca_providers.dart';
 
 /// Provider Computado que atua como Filtro Inteligente.
 /// Observa o estado do fetch da API e os dados locais do usuário,
@@ -29,7 +30,19 @@ final certificadosSispubliDisponiveisProvider =
       }
 
       // 3. Aplica o filtro de deduplicação reativamente
-      return dtosDaApi
+      var lista = dtosDaApi
           .where((dto) => !idsLocais.contains(dto.idUnico))
           .toList();
+
+      // 4. Busca Texto (Case-insensitive e Trim garantidos no Debounce)
+      final query = ref.watch(buscaSispubliDebouncedProvider);
+      if (query.isNotEmpty) {
+        lista = lista.where((dto) {
+          final titulo = dto.titulo.toLowerCase().contains(query);
+          final tipo = dto.tipoDescricao.toLowerCase().contains(query);
+          return titulo || tipo;
+        }).toList();
+      }
+
+      return lista;
     });

--- a/lib/features/sispubli/presentation/sispubli_providers.g.dart
+++ b/lib/features/sispubli/presentation/sispubli_providers.g.dart
@@ -1,0 +1,91 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sispubli_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$anosAtivosSispubliHash() =>
+    r'32d36eaa4f0179d9596ed8072f2db6d80a94c1d8';
+
+/// See also [anosAtivosSispubli].
+@ProviderFor(anosAtivosSispubli)
+final anosAtivosSispubliProvider = AutoDisposeProvider<Set<int>>.internal(
+  anosAtivosSispubli,
+  name: r'anosAtivosSispubliProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$anosAtivosSispubliHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AnosAtivosSispubliRef = AutoDisposeProviderRef<Set<int>>;
+String _$tiposAtivosSispubliHash() =>
+    r'c9517f5c6a37106ecdbb35a4a802c58586b09e9a';
+
+/// See also [tiposAtivosSispubli].
+@ProviderFor(tiposAtivosSispubli)
+final tiposAtivosSispubliProvider = AutoDisposeProvider<Set<String>>.internal(
+  tiposAtivosSispubli,
+  name: r'tiposAtivosSispubliProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$tiposAtivosSispubliHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef TiposAtivosSispubliRef = AutoDisposeProviderRef<Set<String>>;
+String _$certificadosSispubliDisponiveisHash() =>
+    r'afbc2c2d8b3637debf3775f3b5e6a5bb706c6add';
+
+/// Provider Computado que atua como Filtro Inteligente.
+/// Observa o estado do fetch da API e os dados locais do usuário,
+/// retornando apenas os certificados do Sispubli que ainda não
+/// foram salvos no cofre do IFdex.
+///
+/// Copied from [certificadosSispubliDisponiveis].
+@ProviderFor(certificadosSispubliDisponiveis)
+final certificadosSispubliDisponiveisProvider =
+    AutoDisposeProvider<List<SispubliCertificadoDto>>.internal(
+      certificadosSispubliDisponiveis,
+      name: r'certificadosSispubliDisponiveisProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$certificadosSispubliDisponiveisHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef CertificadosSispubliDisponiveisRef =
+    AutoDisposeProviderRef<List<SispubliCertificadoDto>>;
+String _$filtroSispubliNotifierHash() =>
+    r'79542888cf2d792b07259205b8c17716a45f331c';
+
+/// See also [FiltroSispubliNotifier].
+@ProviderFor(FiltroSispubliNotifier)
+final filtroSispubliNotifierProvider =
+    AutoDisposeNotifierProvider<
+      FiltroSispubliNotifier,
+      FiltrosSispubli
+    >.internal(
+      FiltroSispubliNotifier.new,
+      name: r'filtroSispubliNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$filtroSispubliNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$FiltroSispubliNotifier = AutoDisposeNotifier<FiltrosSispubli>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sispubli/widgets/app_filtros_sispubli_bottom_sheet.dart
+++ b/lib/features/sispubli/widgets/app_filtros_sispubli_bottom_sheet.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ifdex/features/sispubli/presentation/sispubli_providers.dart';
+import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
+import 'package:ifdex/shared/providers/ordenacao_providers.dart';
+import 'package:ifdex/shared/models/ordenacao_enum.dart';
+
+class AppFiltrosSispubliBottomSheet extends ConsumerWidget {
+  const AppFiltrosSispubliBottomSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filtros = ref.watch(filtroSispubliNotifierProvider);
+    final tiposAtivosList = ref.watch(tiposAtivosSispubliProvider);
+    final anosAtivosList = ref.watch(anosAtivosSispubliProvider);
+    final ordenacao = ref.watch(ordenacaoSispubliStateProvider);
+
+    return Container(
+      padding: const EdgeInsets.only(top: 24, left: 24, right: 24, bottom: 24),
+      decoration: const BoxDecoration(
+        color: AppColors.background,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              AppText.headline('Filtros da Importação'),
+              TextButton(
+                onPressed: () => ref
+                    .read(filtroSispubliNotifierProvider.notifier)
+                    .limparFiltros(),
+                child: const AppText('Limpar', color: AppColors.primary),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Seção: Ordenação
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.sort,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Ordenar por'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<OrdenacaoSispubli>(
+                    initialValue: ordenacao,
+                    decoration: const InputDecoration(
+                      contentPadding: EdgeInsets.symmetric(horizontal: 12),
+                    ),
+                    items: OrdenacaoSispubli.values.map((o) {
+                      return DropdownMenuItem<OrdenacaoSispubli>(
+                        value: o,
+                        child: Text(o.label),
+                      );
+                    }).toList(),
+                    onChanged: (val) {
+                      if (val != null) {
+                        ref
+                            .read(ordenacaoSispubliStateProvider.notifier)
+                            .setOrdem(val);
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  // Seção: Anos
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.calendar_today,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Ano do Certificado'),
+                      const Spacer(),
+                      AppText(
+                        '${filtros.minAno ?? (anosAtivosList.isNotEmpty ? anosAtivosList.last : 'Todos')} - ${filtros.maxAno ?? (anosAtivosList.isNotEmpty ? anosAtivosList.first : 'Todos')}',
+                        color: AppColors.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (anosAtivosList.isEmpty)
+                    const AppText(
+                      'Nenhum ano detectado.',
+                      color: AppColors.textSecondary,
+                    )
+                  else if (anosAtivosList.length == 1)
+                    AppText(
+                      'Apenas certificados de ${anosAtivosList.first}.',
+                      color: AppColors.textSecondary,
+                    )
+                  else
+                    RangeSlider(
+                      values: RangeValues(
+                        (filtros.minAno ?? anosAtivosList.last).toDouble(),
+                        (filtros.maxAno ?? anosAtivosList.first).toDouble(),
+                      ),
+                      min: anosAtivosList.last.toDouble(),
+                      max: anosAtivosList.first.toDouble(),
+                      divisions: anosAtivosList.first - anosAtivosList.last > 0
+                          ? anosAtivosList.first - anosAtivosList.last
+                          : 1,
+                      activeColor: AppColors.primary,
+                      inactiveColor: AppColors.border,
+                      labels: RangeLabels(
+                        (filtros.minAno ?? anosAtivosList.last).toString(),
+                        (filtros.maxAno ?? anosAtivosList.first).toString(),
+                      ),
+                      onChanged: (RangeValues values) {
+                        ref
+                            .read(filtroSispubliNotifierProvider.notifier)
+                            .setAno(values.start.round(), values.end.round());
+                      },
+                    ),
+                  const SizedBox(height: 24),
+
+                  // Seção: Tipos
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.category,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Tipos de Participação'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (tiposAtivosList.isEmpty)
+                    const AppText(
+                      'Nenhum tipo detectado.',
+                      color: AppColors.textSecondary,
+                    )
+                  else
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Wrap(
+                        spacing: 8,
+                        children: tiposAtivosList.map((tipo) {
+                          final isSelected = filtros.tiposSelecionados.contains(
+                            tipo,
+                          );
+                          return FilterChip(
+                            label: Text(tipo),
+                            selected: isSelected,
+                            selectedColor: AppColors.primarySoft,
+                            checkmarkColor: AppColors.primary,
+                            labelStyle: TextStyle(
+                              color: isSelected
+                                  ? AppColors.primary
+                                  : AppColors.textSecondary,
+                              fontWeight: isSelected
+                                  ? FontWeight.w600
+                                  : FontWeight.w400,
+                            ),
+                            onSelected: (_) => ref
+                                .read(filtroSispubliNotifierProvider.notifier)
+                                .toggleTipo(tipo),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const AppText(
+                'Aplicar Filtros',
+                color: AppColors.textOnPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/sispubli/widgets/sispubli_cpf_form.dart
+++ b/lib/features/sispubli/widgets/sispubli_cpf_form.dart
@@ -24,13 +24,23 @@ class _SispubliCpfFormState extends ConsumerState<SispubliCpfForm> {
     super.dispose();
   }
 
+  bool _isLoading = false;
+
   void _buscar() {
+    if (_isLoading) return;
     if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
 
     final cpfLimpo = _cpfController.text.replaceAll(RegExp(r'\D'), '');
     ref
         .read(sispubliImportViewModelProvider.notifier)
         .buscarCertificados(cpfLimpo);
+
+    // Reset para o caso da árvore não ser desmontada imediatamente (delay)
+    Future.delayed(const Duration(milliseconds: 500), () {
+      if (mounted) setState(() => _isLoading = false);
+    });
   }
 
   @override
@@ -92,10 +102,19 @@ class _SispubliCpfFormState extends ConsumerState<SispubliCpfForm> {
                 SizedBox(
                   width: double.infinity,
                   child: ElevatedButton.icon(
-                    onPressed: _buscar,
-                    icon: const Icon(Icons.search, size: 20),
-                    label: const AppText(
-                      'Buscar Certificados',
+                    onPressed: _isLoading ? null : _buscar,
+                    icon: _isLoading
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: AppColors.textOnPrimary,
+                            ),
+                          )
+                        : const Icon(Icons.search, size: 20),
+                    label: AppText(
+                      _isLoading ? 'Buscando...' : 'Buscar Certificados',
                       color: AppColors.textOnPrimary,
                       fontWeight: FontWeight.w600,
                     ),

--- a/lib/features/sispubli/widgets/sispubli_selection_list.dart
+++ b/lib/features/sispubli/widgets/sispubli_selection_list.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:ifdex/features/sispubli/data/sispubli_datasource.dart';
 import 'package:ifdex/shared/theme/app_theme.dart';
 import 'package:ifdex/shared/widgets/app_text.dart';
+import 'package:ifdex/shared/widgets/app_search_bar.dart';
+import 'package:ifdex/shared/providers/busca_providers.dart';
 
 /// Fase 2: Componente isolado para selecionar DTOs através de checkboxes.
 /// Recebe a lista disponível (já deduplicada pelo Provider Computado)
 /// e avisa a view pai quando o usuário decide "Importar".
-class SispubliSelectionList extends StatefulWidget {
+class SispubliSelectionList extends ConsumerStatefulWidget {
   final List<SispubliCertificadoDto> disponiveis;
   final ValueChanged<List<SispubliCertificadoDto>> onImportar;
 
@@ -18,10 +22,11 @@ class SispubliSelectionList extends StatefulWidget {
   });
 
   @override
-  State<SispubliSelectionList> createState() => _SispubliSelectionListState();
+  ConsumerState<SispubliSelectionList> createState() =>
+      _SispubliSelectionListState();
 }
 
-class _SispubliSelectionListState extends State<SispubliSelectionList> {
+class _SispubliSelectionListState extends ConsumerState<SispubliSelectionList> {
   final Set<String> _selecionados = {};
   bool _selecionarTodos = false;
 
@@ -61,6 +66,18 @@ class _SispubliSelectionListState extends State<SispubliSelectionList> {
 
     return Column(
       children: [
+        // Busca
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+          child: AppSearchBar(
+            hintText: 'Filtrar disponíveis...',
+            initialValue: ref.read(buscaSispubliProvider),
+            onChanged: (val) {
+              ref.read(buscaSispubliProvider.notifier).setQuery(val);
+            },
+          ),
+        ),
+
         // Header com info e "Selecionar Todos"
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),

--- a/lib/features/sispubli/widgets/sispubli_selection_list.dart
+++ b/lib/features/sispubli/widgets/sispubli_selection_list.dart
@@ -7,6 +7,7 @@ import 'package:ifdex/shared/theme/app_theme.dart';
 import 'package:ifdex/shared/widgets/app_text.dart';
 import 'package:ifdex/shared/widgets/app_search_bar.dart';
 import 'package:ifdex/shared/providers/busca_providers.dart';
+import 'package:ifdex/features/sispubli/widgets/app_filtros_sispubli_bottom_sheet.dart';
 
 /// Fase 2: Componente isolado para selecionar DTOs através de checkboxes.
 /// Recebe a lista disponível (já deduplicada pelo Provider Computado)
@@ -104,6 +105,22 @@ class _SispubliSelectionListState extends ConsumerState<SispubliSelectionList> {
                 ),
               ),
               const Spacer(),
+              IconButton(
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    backgroundColor: Colors.transparent,
+                    builder: (_) => const AppFiltrosSispubliBottomSheet(),
+                  );
+                },
+                tooltip: 'Filtrar e Ordenar',
+                icon: const Icon(
+                  Icons.tune,
+                  color: AppColors.primary,
+                  size: 20,
+                ),
+              ),
               TextButton.icon(
                 onPressed: _toggleTodos,
                 icon: Icon(

--- a/lib/shared/models/filtros_globais.dart
+++ b/lib/shared/models/filtros_globais.dart
@@ -1,0 +1,59 @@
+class FiltrosGlobais {
+  final Set<String> instituicoesSelecionadas;
+  final Set<int> estrelasSelecionadas;
+  final int? minAno;
+  final int? maxAno;
+  final Set<String> tiposSelecionados;
+  final Set<String> tagsSelecionadas;
+  final int minCargaHoraria;
+  final int maxCargaHoraria;
+  final String origemSelecionada;
+
+  const FiltrosGlobais({
+    this.instituicoesSelecionadas = const {},
+    this.estrelasSelecionadas = const {},
+    this.minAno,
+    this.maxAno,
+    this.tiposSelecionados = const {},
+    this.tagsSelecionadas = const {},
+    this.minCargaHoraria = 0,
+    this.maxCargaHoraria = 5000,
+    this.origemSelecionada = 'todos',
+  });
+
+  FiltrosGlobais copyWith({
+    Set<String>? instituicoesSelecionadas,
+    Set<int>? estrelasSelecionadas,
+    int? minAno,
+    int? maxAno,
+    Set<String>? tiposSelecionados,
+    Set<String>? tagsSelecionadas,
+    int? minCargaHoraria,
+    int? maxCargaHoraria,
+    String? origemSelecionada,
+  }) {
+    return FiltrosGlobais(
+      instituicoesSelecionadas:
+          instituicoesSelecionadas ?? this.instituicoesSelecionadas,
+      estrelasSelecionadas: estrelasSelecionadas ?? this.estrelasSelecionadas,
+      minAno: minAno ?? this.minAno,
+      maxAno: maxAno ?? this.maxAno,
+      tiposSelecionados: tiposSelecionados ?? this.tiposSelecionados,
+      tagsSelecionadas: tagsSelecionadas ?? this.tagsSelecionadas,
+      minCargaHoraria: minCargaHoraria ?? this.minCargaHoraria,
+      maxCargaHoraria: maxCargaHoraria ?? this.maxCargaHoraria,
+      origemSelecionada: origemSelecionada ?? this.origemSelecionada,
+    );
+  }
+
+  bool get isEmpty =>
+      instituicoesSelecionadas.isEmpty &&
+      estrelasSelecionadas.isEmpty &&
+      minAno == null &&
+      maxAno == null &&
+      tiposSelecionados.isEmpty &&
+      tagsSelecionadas.isEmpty &&
+      minCargaHoraria == 0 &&
+      maxCargaHoraria == 5000 &&
+      origemSelecionada == 'todos';
+}

--- a/lib/shared/models/ordenacao_enum.dart
+++ b/lib/shared/models/ordenacao_enum.dart
@@ -1,0 +1,21 @@
+enum OrdenacaoHome {
+  anoDesc('Ano: Mais Recente'),
+  anoAsc('Ano: Mais Antigo'),
+  relevanciaDesc('Maior Relevância'),
+  cargaHorariaDesc('Maior Carga Horária'),
+  tituloAsc('Título (A-Z)'),
+  tituloDesc('Título (Z-A)');
+
+  final String label;
+  const OrdenacaoHome(this.label);
+}
+
+enum OrdenacaoSispubli {
+  anoDesc('Ano: Mais Recente'),
+  anoAsc('Ano: Mais Antigo'),
+  tituloAsc('Título (A-Z)'),
+  tituloDesc('Título (Z-A)');
+
+  final String label;
+  const OrdenacaoSispubli(this.label);
+}

--- a/lib/shared/providers/busca_providers.dart
+++ b/lib/shared/providers/busca_providers.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'busca_providers.g.dart';
+
+// ==========================================
+// HOME - COFRE LOCAL
+// ==========================================
+
+/// Estado global em tempo real (1:1 com a digitação do teclado)
+@riverpod
+class BuscaHome extends _$BuscaHome {
+  @override
+  String build() => '';
+
+  void setQuery(String query) {
+    state = query;
+  }
+}
+
+/// Estado com Debounce (Atraso de 300ms) - Síncrono
+@riverpod
+class BuscaHomeDebounced extends _$BuscaHomeDebounced {
+  Timer? _timer;
+
+  @override
+  String build() {
+    // Fica escutando as mudanças do texto bruto sem re-executar o build
+    ref.listen<String>(buscaHomeProvider, (previous, next) {
+      _timer?.cancel();
+      _timer = Timer(const Duration(milliseconds: 300), () {
+        // Quando estoura, aplica trim e lowercase logo na origem para garantir a sanidade
+        state = next.trim().toLowerCase();
+      });
+    });
+
+    ref.onDispose(() {
+      _timer?.cancel();
+    });
+
+    // Estado inicial
+    return ref.read(buscaHomeProvider).trim().toLowerCase();
+  }
+}
+
+// ==========================================
+// SISPUBLI - IMPORTAÇÃO
+// ==========================================
+
+/// Estado global em tempo real
+@riverpod
+class BuscaSispubli extends _$BuscaSispubli {
+  @override
+  String build() => '';
+
+  void setQuery(String query) {
+    state = query;
+  }
+}
+
+/// Estado com Debounce para o Sispubli (Atraso de 300ms)
+@riverpod
+class BuscaSispubliDebounced extends _$BuscaSispubliDebounced {
+  Timer? _timer;
+
+  @override
+  String build() {
+    ref.listen<String>(buscaSispubliProvider, (previous, next) {
+      _timer?.cancel();
+      _timer = Timer(const Duration(milliseconds: 300), () {
+        state = next.trim().toLowerCase();
+      });
+    });
+
+    ref.onDispose(() {
+      _timer?.cancel();
+    });
+
+    return ref.read(buscaSispubliProvider).trim().toLowerCase();
+  }
+}

--- a/lib/shared/providers/busca_providers.g.dart
+++ b/lib/shared/providers/busca_providers.g.dart
@@ -1,0 +1,84 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'busca_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$buscaHomeHash() => r'ec39cde4a4ce566e308e50d5f6096079cfb9e699';
+
+/// Estado global em tempo real (1:1 com a digitação do teclado)
+///
+/// Copied from [BuscaHome].
+@ProviderFor(BuscaHome)
+final buscaHomeProvider =
+    AutoDisposeNotifierProvider<BuscaHome, String>.internal(
+      BuscaHome.new,
+      name: r'buscaHomeProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$buscaHomeHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$BuscaHome = AutoDisposeNotifier<String>;
+String _$buscaHomeDebouncedHash() =>
+    r'590ff74cd5f5fc5fdabdb31baa81f65f2ca90563';
+
+/// Estado com Debounce (Atraso de 300ms) - Síncrono
+///
+/// Copied from [BuscaHomeDebounced].
+@ProviderFor(BuscaHomeDebounced)
+final buscaHomeDebouncedProvider =
+    AutoDisposeNotifierProvider<BuscaHomeDebounced, String>.internal(
+      BuscaHomeDebounced.new,
+      name: r'buscaHomeDebouncedProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$buscaHomeDebouncedHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$BuscaHomeDebounced = AutoDisposeNotifier<String>;
+String _$buscaSispubliHash() => r'05f385018e6f3b748c18a760d95bf477b53f6b55';
+
+/// Estado global em tempo real
+///
+/// Copied from [BuscaSispubli].
+@ProviderFor(BuscaSispubli)
+final buscaSispubliProvider =
+    AutoDisposeNotifierProvider<BuscaSispubli, String>.internal(
+      BuscaSispubli.new,
+      name: r'buscaSispubliProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$buscaSispubliHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$BuscaSispubli = AutoDisposeNotifier<String>;
+String _$buscaSispubliDebouncedHash() =>
+    r'2e7acbd4077eab3c38f421705c7a3a23e184aad6';
+
+/// Estado com Debounce para o Sispubli (Atraso de 300ms)
+///
+/// Copied from [BuscaSispubliDebounced].
+@ProviderFor(BuscaSispubliDebounced)
+final buscaSispubliDebouncedProvider =
+    AutoDisposeNotifierProvider<BuscaSispubliDebounced, String>.internal(
+      BuscaSispubliDebounced.new,
+      name: r'buscaSispubliDebouncedProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$buscaSispubliDebouncedHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$BuscaSispubliDebounced = AutoDisposeNotifier<String>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/shared/providers/ordenacao_providers.dart
+++ b/lib/shared/providers/ordenacao_providers.dart
@@ -1,0 +1,20 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:ifdex/shared/models/ordenacao_enum.dart';
+
+part 'ordenacao_providers.g.dart';
+
+@riverpod
+class OrdenacaoHomeState extends _$OrdenacaoHomeState {
+  @override
+  OrdenacaoHome build() => OrdenacaoHome.anoDesc;
+
+  void setOrdem(OrdenacaoHome novaOrdem) => state = novaOrdem;
+}
+
+@riverpod
+class OrdenacaoSispubliState extends _$OrdenacaoSispubliState {
+  @override
+  OrdenacaoSispubli build() => OrdenacaoSispubli.anoDesc;
+
+  void setOrdem(OrdenacaoSispubli novaOrdem) => state = novaOrdem;
+}

--- a/lib/shared/providers/ordenacao_providers.g.dart
+++ b/lib/shared/providers/ordenacao_providers.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ordenacao_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$ordenacaoHomeStateHash() =>
+    r'6279d3b2fa0e3bab2c4b113353f39bb98efac490';
+
+/// See also [OrdenacaoHomeState].
+@ProviderFor(OrdenacaoHomeState)
+final ordenacaoHomeStateProvider =
+    AutoDisposeNotifierProvider<OrdenacaoHomeState, OrdenacaoHome>.internal(
+      OrdenacaoHomeState.new,
+      name: r'ordenacaoHomeStateProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$ordenacaoHomeStateHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$OrdenacaoHomeState = AutoDisposeNotifier<OrdenacaoHome>;
+String _$ordenacaoSispubliStateHash() =>
+    r'0d302477d108f7e28008e8fc344e847f84971274';
+
+/// See also [OrdenacaoSispubliState].
+@ProviderFor(OrdenacaoSispubliState)
+final ordenacaoSispubliStateProvider =
+    AutoDisposeNotifierProvider<
+      OrdenacaoSispubliState,
+      OrdenacaoSispubli
+    >.internal(
+      OrdenacaoSispubliState.new,
+      name: r'ordenacaoSispubliStateProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$ordenacaoSispubliStateHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$OrdenacaoSispubliState = AutoDisposeNotifier<OrdenacaoSispubli>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/shared/widgets/app_filtros_bottom_sheet.dart
+++ b/lib/shared/widgets/app_filtros_bottom_sheet.dart
@@ -1,0 +1,424 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:ifdex/features/certificados/presentation/certificados_view_model.dart';
+import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
+import 'package:ifdex/shared/providers/ordenacao_providers.dart';
+import 'package:ifdex/shared/models/ordenacao_enum.dart';
+
+class AppFiltrosBottomSheet extends ConsumerWidget {
+  const AppFiltrosBottomSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filtros = ref.watch(filtroCertificadosProvider);
+    final instAtivas = ref.watch(instituicoesAtivasProvider);
+    final tiposAtivosList = ref.watch(tiposAtivosProvider);
+    final tagsAtivasList = ref.watch(tagsAtivasProvider);
+    final anosAtivosList = ref.watch(anosAtivosProvider);
+    final ordenacao = ref.watch(ordenacaoHomeStateProvider);
+
+    return Container(
+      padding: const EdgeInsets.only(top: 24, left: 24, right: 24, bottom: 24),
+      decoration: const BoxDecoration(
+        color: AppColors.background,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              AppText.headline('Filtros Avançados'),
+              TextButton(
+                onPressed: () => ref
+                    .read(filtroCertificadosProvider.notifier)
+                    .limparFiltros(),
+                child: const AppText('Limpar', color: AppColors.primary),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Seção: Ordenação
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.sort,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Ordenar por'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<OrdenacaoHome>(
+                    initialValue: ordenacao,
+                    decoration: const InputDecoration(
+                      contentPadding: EdgeInsets.symmetric(horizontal: 12),
+                    ),
+                    items: OrdenacaoHome.values.map((o) {
+                      return DropdownMenuItem<OrdenacaoHome>(
+                        value: o,
+                        child: Text(o.label),
+                      );
+                    }).toList(),
+                    onChanged: (val) {
+                      if (val != null) {
+                        ref
+                            .read(ordenacaoHomeStateProvider.notifier)
+                            .setOrdem(val);
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 24),
+
+                  // Seção 1: Origem
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.source,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Origem do Certificado'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  SegmentedButton<String>(
+                    segments: const [
+                      ButtonSegment(value: 'todos', label: Text('Todos')),
+                      ButtonSegment(value: 'oficial', label: Text('Oficiais')),
+                      ButtonSegment(value: 'manual', label: Text('Manuais')),
+                    ],
+                    selected: {filtros.origemSelecionada},
+                    onSelectionChanged: (set) {
+                      if (set.isNotEmpty) {
+                        ref
+                            .read(filtroCertificadosProvider.notifier)
+                            .setOrigem(set.first);
+                      }
+                    },
+                    style: SegmentedButton.styleFrom(
+                      selectedBackgroundColor: AppColors.primarySoft,
+                      selectedForegroundColor: AppColors.primary,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+
+                  // Seção: Anos
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.calendar_today,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Ano do Certificado'),
+                      const Spacer(),
+                      AppText(
+                        '${filtros.minAno ?? (anosAtivosList.isNotEmpty ? anosAtivosList.last : 'Todos')} - ${filtros.maxAno ?? (anosAtivosList.isNotEmpty ? anosAtivosList.first : 'Todos')}',
+                        color: AppColors.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (anosAtivosList.isEmpty)
+                    const AppText(
+                      'Nenhum ano detectado.',
+                      color: AppColors.textSecondary,
+                    )
+                  else if (anosAtivosList.length == 1)
+                    AppText(
+                      'Apenas certificados de ${anosAtivosList.first}.',
+                      color: AppColors.textSecondary,
+                    )
+                  else
+                    RangeSlider(
+                      values: RangeValues(
+                        (filtros.minAno ?? anosAtivosList.last).toDouble(),
+                        (filtros.maxAno ?? anosAtivosList.first).toDouble(),
+                      ),
+                      min: anosAtivosList.last.toDouble(),
+                      max: anosAtivosList.first.toDouble(),
+                      divisions: anosAtivosList.first - anosAtivosList.last > 0
+                          ? anosAtivosList.first - anosAtivosList.last
+                          : 1,
+                      activeColor: AppColors.primary,
+                      inactiveColor: AppColors.border,
+                      labels: RangeLabels(
+                        (filtros.minAno ?? anosAtivosList.last).toString(),
+                        (filtros.maxAno ?? anosAtivosList.first).toString(),
+                      ),
+                      onChanged: (RangeValues values) {
+                        ref
+                            .read(filtroCertificadosProvider.notifier)
+                            .setAno(values.start.round(), values.end.round());
+                      },
+                    ),
+                  const SizedBox(height: 24),
+
+                  // Seção: Tipos
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.category,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Tipos de Participação'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (tiposAtivosList.isEmpty)
+                    const AppText(
+                      'Nenhum tipo detectado.',
+                      color: AppColors.textSecondary,
+                    )
+                  else
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Wrap(
+                        spacing: 8,
+                        children: tiposAtivosList.map((tipo) {
+                          final isSelected = filtros.tiposSelecionados.contains(
+                            tipo,
+                          );
+                          return FilterChip(
+                            label: Text(tipo),
+                            selected: isSelected,
+                            selectedColor: AppColors.primarySoft,
+                            checkmarkColor: AppColors.primary,
+                            labelStyle: TextStyle(
+                              color: isSelected
+                                  ? AppColors.primary
+                                  : AppColors.textSecondary,
+                              fontWeight: isSelected
+                                  ? FontWeight.w600
+                                  : FontWeight.w400,
+                            ),
+                            onSelected: (_) => ref
+                                .read(filtroCertificadosProvider.notifier)
+                                .toggleTipo(tipo),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  const SizedBox(height: 24),
+
+                  // Seção 2: Instituições
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.business,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Instituições / Plataformas'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (instAtivas.isEmpty)
+                    const AppText(
+                      'Nenhuma instituição detectada.',
+                      color: AppColors.textSecondary,
+                    )
+                  else
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Wrap(
+                        spacing: 8,
+                        children: instAtivas.map((inst) {
+                          final isSelected = filtros.instituicoesSelecionadas
+                              .contains(inst);
+                          return FilterChip(
+                            label: Text(inst),
+                            selected: isSelected,
+                            selectedColor: AppColors.primarySoft,
+                            checkmarkColor: AppColors.primary,
+                            labelStyle: TextStyle(
+                              color: isSelected
+                                  ? AppColors.primary
+                                  : AppColors.textSecondary,
+                              fontWeight: isSelected
+                                  ? FontWeight.w600
+                                  : FontWeight.w400,
+                            ),
+                            onSelected: (_) => ref
+                                .read(filtroCertificadosProvider.notifier)
+                                .toggleInstituicao(inst),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  const SizedBox(height: 24),
+
+                  // Seção: Tags
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.local_offer,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Tags'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (tagsAtivasList.isEmpty)
+                    const AppText(
+                      'Nenhuma tag detectada.',
+                      color: AppColors.textSecondary,
+                    )
+                  else
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Wrap(
+                        spacing: 8,
+                        children: tagsAtivasList.map((tag) {
+                          final isSelected = filtros.tagsSelecionadas.contains(
+                            tag,
+                          );
+                          return FilterChip(
+                            label: Text(tag),
+                            selected: isSelected,
+                            selectedColor: AppColors.primarySoft,
+                            checkmarkColor: AppColors.primary,
+                            labelStyle: TextStyle(
+                              color: isSelected
+                                  ? AppColors.primary
+                                  : AppColors.textSecondary,
+                              fontWeight: isSelected
+                                  ? FontWeight.w600
+                                  : FontWeight.w400,
+                            ),
+                            onSelected: (_) => ref
+                                .read(filtroCertificadosProvider.notifier)
+                                .toggleTag(tag),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  const SizedBox(height: 24),
+
+                  // Seção 3: Estrelas
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.star_outline,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Nota de Relevância (Estrelas)'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    children: List.generate(5, (index) {
+                      final estrela = index + 1;
+                      final isSelected = filtros.estrelasSelecionadas.contains(
+                        estrela,
+                      );
+                      return FilterChip(
+                        label: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text('$estrela '),
+                            Icon(
+                              Icons.star,
+                              size: 14,
+                              color: isSelected
+                                  ? AppColors.warning
+                                  : AppColors.textDisabled,
+                            ),
+                          ],
+                        ),
+                        selected: isSelected,
+                        selectedColor: AppColors.warning.withValues(alpha: 0.1),
+                        checkmarkColor: AppColors.warning,
+                        onSelected: (_) => ref
+                            .read(filtroCertificadosProvider.notifier)
+                            .toggleEstrela(estrela),
+                      );
+                    }),
+                  ),
+                  const SizedBox(height: 24),
+
+                  // Seção 4: Carga Horária
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.timer,
+                        size: 16,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      AppText.label('Carga Horária (horas)'),
+                      const Spacer(),
+                      AppText(
+                        '${filtros.minCargaHoraria}h - ${filtros.maxCargaHoraria}h',
+                        color: AppColors.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ],
+                  ),
+                  RangeSlider(
+                    values: RangeValues(
+                      filtros.minCargaHoraria.toDouble(),
+                      filtros.maxCargaHoraria.toDouble(),
+                    ),
+                    min: 0,
+                    max: 5000,
+                    divisions: 100,
+                    activeColor: AppColors.primary,
+                    inactiveColor: AppColors.border,
+                    onChanged: (RangeValues values) {
+                      ref
+                          .read(filtroCertificadosProvider.notifier)
+                          .setCargaHoraria(
+                            values.start.round(),
+                            values.end.round(),
+                          );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const AppText(
+                'Aplicar Filtros',
+                color: AppColors.textOnPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/app_search_bar.dart
+++ b/lib/shared/widgets/app_search_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ifdex/shared/theme/app_theme.dart';
+
+class AppSearchBar extends ConsumerStatefulWidget {
+  final String hintText;
+  final String initialValue;
+  final ValueChanged<String> onChanged;
+
+  const AppSearchBar({
+    super.key,
+    this.hintText = 'Buscar certificados...',
+    this.initialValue = '',
+    required this.onChanged,
+  });
+
+  @override
+  ConsumerState<AppSearchBar> createState() => _AppSearchBarState();
+}
+
+class _AppSearchBarState extends ConsumerState<AppSearchBar> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _clear() {
+    _controller.clear();
+    widget.onChanged('');
+    setState(() {}); // Atualiza UI para remover botão X
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: TextField(
+        controller: _controller,
+        onChanged: (val) {
+          widget.onChanged(val);
+          setState(() {}); // Atualiza UI para exibir/remover botão X
+        },
+        style: const TextStyle(
+          fontFamily: 'Inter',
+          color: AppColors.textPrimary,
+          fontSize: 14,
+        ),
+        decoration: InputDecoration(
+          hintText: widget.hintText,
+          hintStyle: const TextStyle(color: AppColors.textMuted, fontSize: 14),
+          prefixIcon: const Icon(
+            Icons.search,
+            color: AppColors.textSecondary,
+            size: 20,
+          ),
+          suffixIcon: _controller.text.isNotEmpty
+              ? IconButton(
+                  icon: const Icon(
+                    Icons.close,
+                    color: AppColors.textSecondary,
+                    size: 18,
+                  ),
+                  onPressed: _clear,
+                )
+              : null,
+          border: InputBorder.none,
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 14,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/certificados/models/certificado_test.dart
+++ b/test/features/certificados/models/certificado_test.dart
@@ -233,7 +233,7 @@ void main() {
             (e) => e.message,
             'message',
             'O título é obrigatório e deve ter '
-                'no máximo 100 caracteres.',
+                'no máximo 255 caracteres.',
           ),
         ),
       );
@@ -250,24 +250,22 @@ void main() {
             (e) => e.message,
             'message',
             'O título é obrigatório e deve ter '
-                'no máximo 100 caracteres.',
+                'no máximo 255 caracteres.',
           ),
         ),
       );
     });
 
-    test('#13 Deve lançar erro se o título ultrapassar '
-        '100 caracteres', () {
-      final p = baseManual()..['titulo'] = 'A' * 101;
-
+    test('#13 Deve lançar erro se o título ultrapassar 255 caracteres', () {
+      final map = baseManual()..['titulo'] = 'A' * 256;
       expect(
-        () => criar(p),
+        () => criar(map),
         throwsA(
           isA<ArgumentError>().having(
             (e) => e.message,
             'message',
             'O título é obrigatório e deve ter '
-                'no máximo 100 caracteres.',
+                'no máximo 255 caracteres.',
           ),
         ),
       );
@@ -394,11 +392,10 @@ void main() {
       expect(certMax.notaRelevancia, 5);
     });
 
-    test('#20 Deve aceitar um título com exatamente '
-        '100 caracteres', () {
-      final titulo100 = 'A' * 100;
-      final cert = criar(baseManual()..['titulo'] = titulo100);
-      expect(cert.titulo.length, 100);
+    test('#20 Deve aceitar um título com exatamente 255 caracteres', () {
+      final titulo255 = 'A' * 255;
+      final cert = criar(baseManual()..['titulo'] = titulo255);
+      expect(cert.titulo.length, 255);
     });
   });
 


### PR DESCRIPTION
<!-- AGENTE MCP / IA: Ao analisar este Pull Request, verifique de forma autônoma se o código viola a regra de não utilizar tipos 'dynamic'. Se o PR alterar a pasta lib/views/ ou lib/widgets/, exija a presença de screenshots de prova visual no corpo da descrição abaixo. -->

# 🔗 Link para a Issue resolvida

Closes #34
Closes #35
## 📋 Checklist Obrigatório

Antes de colocar seu PR para revisão, ateste que cumpriu os padrões do repositório:

- [x] Eu rodei `make check` e não há erros de Linter ou formatação.
- [x] Eu escrevi testes automatizados para essa alteração (se aplicável).
- [x] Meu código não utiliza `dynamic` e respeita as regras de tipagem estrita.

---

## 🖼️ Prova Visual (A Regra do "Me Prove")

Se você alterou elementos de interface do Flutter (`lib/views/` ou `lib/widgets/`), é **obrigatório** anexar evidências visuais do Antes e Depois. Isso elimina o atrito de compilação apenas para revisão de UI.

> *Lembrete: Cole aqui os screenshots ou um pequeno GIF demonstrando a nova Barra de Busca, o Botão Consolidado de Filtros/Ordenação e as travas de `isLoading` dos botões sendo ativadas.*

---

## 🤔 Reflexão Estratégica

Evite a "aprovação no piloto automático" respondendo:

**1. Qual foi o caso extremo (edge case) que você considerou ao codificar essa funcionalidade ou teste?**
> **1.** Prevenção de concorrência de requisições: os usuários poderiam dar "double tap" em botões assíncronos (como login, exclusão ou importar do Sispubli), acionando múltiplas chamadas à mesma API simultaneamente. Resolvemos blindando toda a UI com validadores de estado de `isLoading`.  
> **2.** O estouro de limite de caracteres por causa de importações do Sispubli com nomes longos (ex: ~140 caracteres). O limite rígido no modelo e no Firebase bloqueava a ação. Solucionamos elevando o limite da entidade, do banco (`firestore.rules`), dos validadores do forms e de todos os testes unitários para **255 caracteres**, utilizando graciosamente `maxLines: 2` com reticências nos componentes para nunca quebrar a UI.

**2. Foi deixado algum débito técnico consciente nesta entrega? Se sim, qual e o porquê?**
> Consolidamos os botões de Filtro e Ordenação em um único Bottom Sheet (gaveta que sobe da tela) em vez de manter uma barra horizontal separada na UI principal. Essa decisão consciente foi tomada para priorizar o respiro de design (*white space*) e evitar a "poluição" visual na versão mobile. Do ponto de vista técnico, acopla temporariamente os Providers de busca e de ordenação dentro da mesma view de fundo, mas compensa amplamente na usabilidade para o usuário final.
