### PR TITLE
Feat/16 visualizacao de pdf

### DIFF
--- a/lib/features/certificados/data/certificado_arquivo_datasource.dart
+++ b/lib/features/certificados/data/certificado_arquivo_datasource.dart
@@ -67,28 +67,42 @@ class CertificadoArquivoDatasource {
   }
 
   /// Faz o download do arquivo binário sob demanda do Supabase.
-  Future<Uint8List?> downloadArquivo(
-    String uid,
-    String certificadoId, {
-    String ext = '.pdf',
-  }) async {
-    try {
-      final caminho = '$uid/$certificadoId$ext';
-      return await _supabase.storage.from(_bucket).download(caminho);
-    } catch (e) {
-      return null;
+  Future<Uint8List?> downloadArquivo(String uid, String certificadoId) async {
+    for (final ext in ['.pdf', '.png', '.jpg']) {
+      try {
+        final caminho = '$uid/$certificadoId$ext';
+        return await _supabase.storage.from(_bucket).download(caminho);
+      } catch (e) {
+        continue;
+      }
     }
+    return null;
+  }
+
+  /// Obtém uma URL assinada temporária (válida por 60s) para visualização em stream.
+  Future<String?> obterUrlAssinada(String uid, String certificadoId) async {
+    for (final ext in ['.pdf', '.png', '.jpg']) {
+      try {
+        final caminho = '$uid/$certificadoId$ext';
+        return await _supabase.storage
+            .from(_bucket)
+            .createSignedUrl(caminho, 60);
+      } catch (e) {
+        continue;
+      }
+    }
+    return null;
   }
 
   /// Remove o arquivo do Supabase Storage.
-  Future<void> removerArquivo(
-    String uid,
-    String certificadoId, {
-    String ext = '.pdf',
-  }) async {
+  Future<void> removerArquivo(String uid, String certificadoId) async {
     try {
-      final caminho = '$uid/$certificadoId$ext';
-      await _supabase.storage.from(_bucket).remove([caminho]);
+      final caminhos = [
+        '.pdf',
+        '.png',
+        '.jpg',
+      ].map((ext) => '$uid/$certificadoId$ext').toList();
+      await _supabase.storage.from(_bucket).remove(caminhos);
     } catch (e) {
       // Ignora erro se o arquivo não existir
     }

--- a/lib/features/certificados/data/certificado_arquivo_datasource.dart
+++ b/lib/features/certificados/data/certificado_arquivo_datasource.dart
@@ -27,12 +27,11 @@ class CertificadoArquivoDatasource {
 
   /// Faz o upload de um arquivo binário para o Supabase.
   /// Lança [StorageFileSizeException] se exceder 10MB.
-  Future<void> uploadArquivo(
+  Future<String> uploadArquivo(
     String uid,
     String certificadoId,
     Uint8List bytes,
-    String
-    fileName, // Mantido por compatibilidade com a assinatura, mas path é pdf/jpg
+    String fileName,
   ) async {
     if (bytes.lengthInBytes > _maxSizeInBytes) {
       throw StorageFileSizeException(
@@ -62,47 +61,46 @@ class CertificadoArquivoDatasource {
         .uploadBinary(
           caminho,
           bytes,
-          fileOptions: FileOptions(upsert: true, contentType: contentType),
+          fileOptions: FileOptions(contentType: contentType),
         );
+
+    return ext;
   }
 
-  /// Faz o download do arquivo binário sob demanda do Supabase.
-  Future<Uint8List?> downloadArquivo(String uid, String certificadoId) async {
-    for (final ext in ['.pdf', '.png', '.jpg']) {
-      try {
-        final caminho = '$uid/$certificadoId$ext';
-        return await _supabase.storage.from(_bucket).download(caminho);
-      } catch (e) {
-        continue;
-      }
-    }
-    return null;
-  }
-
-  /// Obtém uma URL assinada temporária (válida por 60s) para visualização em stream.
-  Future<String?> obterUrlAssinada(String uid, String certificadoId) async {
-    for (final ext in ['.pdf', '.png', '.jpg']) {
-      try {
-        final caminho = '$uid/$certificadoId$ext';
-        return await _supabase.storage
-            .from(_bucket)
-            .createSignedUrl(caminho, 60);
-      } catch (e) {
-        continue;
-      }
-    }
-    return null;
-  }
-
-  /// Remove o arquivo do Supabase Storage.
-  Future<void> removerArquivo(String uid, String certificadoId) async {
+  Future<Uint8List?> downloadArquivo(
+    String uid,
+    String certificadoId,
+    String formatoArquivo,
+  ) async {
     try {
-      final caminhos = [
-        '.pdf',
-        '.png',
-        '.jpg',
-      ].map((ext) => '$uid/$certificadoId$ext').toList();
-      await _supabase.storage.from(_bucket).remove(caminhos);
+      final caminho = '$uid/$certificadoId$formatoArquivo';
+      return await _supabase.storage.from(_bucket).download(caminho);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<String?> obterUrlAssinada(
+    String uid,
+    String certificadoId,
+    String formatoArquivo,
+  ) async {
+    try {
+      final caminho = '$uid/$certificadoId$formatoArquivo';
+      return await _supabase.storage.from(_bucket).createSignedUrl(caminho, 60);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<void> removerArquivo(
+    String uid,
+    String certificadoId,
+    String formatoArquivo,
+  ) async {
+    try {
+      final caminho = '$uid/$certificadoId$formatoArquivo';
+      await _supabase.storage.from(_bucket).remove([caminho]);
     } catch (e) {
       // Ignora erro se o arquivo não existir
     }

--- a/lib/features/certificados/data/certificado_repository.dart
+++ b/lib/features/certificados/data/certificado_repository.dart
@@ -62,6 +62,11 @@ class CertificadoRepository {
     return _arquivoDatasource.downloadArquivo(_uid, certificadoId);
   }
 
+  /// Retorna uma URL assinada válida por 60 segundos para consumo via streaming.
+  Future<String?> obterUrlAssinada(String certificadoId) async {
+    return _arquivoDatasource.obterUrlAssinada(_uid, certificadoId);
+  }
+
   /// Remove o certificado e seu arquivo binário (se existir).
   Future<void> remover(String certificadoId) async {
     await _firestoreDatasource.remover(_uid, certificadoId);

--- a/lib/features/certificados/data/certificado_repository.dart
+++ b/lib/features/certificados/data/certificado_repository.dart
@@ -44,13 +44,14 @@ class CertificadoRepository {
   Future<void> adicionar(Certificado certificado, {String? fileName}) async {
     // Se há um arquivo transitório, tenta fazer o upload na segunda coleção
     if (certificado.uploadDocumento != null && fileName != null) {
-      await _arquivoDatasource.uploadArquivo(
+      final ext = await _arquivoDatasource.uploadArquivo(
         _uid,
         certificado.id,
         certificado.uploadDocumento!,
         fileName,
       );
       certificado.temArquivo = true;
+      certificado.formatoArquivo = ext;
     }
 
     // Salva metadados (note que uploadDocumento não é salvo no toMap)
@@ -58,19 +59,31 @@ class CertificadoRepository {
   }
 
   /// Faz o download do binário atrelado a este certificado.
-  Future<Uint8List?> carregarArquivo(String certificadoId) async {
-    return _arquivoDatasource.downloadArquivo(_uid, certificadoId);
+  Future<Uint8List?> carregarArquivo(Certificado certificado) async {
+    return _arquivoDatasource.downloadArquivo(
+      _uid,
+      certificado.id,
+      certificado.formatoArquivo,
+    );
   }
 
   /// Retorna uma URL assinada válida por 60 segundos para consumo via streaming.
-  Future<String?> obterUrlAssinada(String certificadoId) async {
-    return _arquivoDatasource.obterUrlAssinada(_uid, certificadoId);
+  Future<String?> obterUrlAssinada(Certificado certificado) async {
+    return _arquivoDatasource.obterUrlAssinada(
+      _uid,
+      certificado.id,
+      certificado.formatoArquivo,
+    );
   }
 
   /// Remove o certificado e seu arquivo binário (se existir).
-  Future<void> remover(String certificadoId) async {
-    await _firestoreDatasource.remover(_uid, certificadoId);
+  Future<void> remover(Certificado certificado) async {
+    await _firestoreDatasource.remover(_uid, certificado.id);
     // Tenta deletar o arquivo sem se importar se havia ou não
-    await _arquivoDatasource.removerArquivo(_uid, certificadoId);
+    await _arquivoDatasource.removerArquivo(
+      _uid,
+      certificado.id,
+      certificado.formatoArquivo,
+    );
   }
 }

--- a/lib/features/certificados/models/certificado.dart
+++ b/lib/features/certificados/models/certificado.dart
@@ -24,6 +24,7 @@ class Certificado {
   String? urlDocumento;
   Uint8List? uploadDocumento; // Transitório: usado apenas no upload
   bool temArquivo;
+  String formatoArquivo;
   List<String> tags;
   int notaRelevancia;
 
@@ -39,6 +40,7 @@ class Certificado {
     this.urlDocumento,
     this.uploadDocumento,
     this.temArquivo = false,
+    this.formatoArquivo = '.pdf',
     required this.tags,
     required this.notaRelevancia,
   });
@@ -58,6 +60,7 @@ class Certificado {
     String? urlDocumento,
     Uint8List? uploadDocumento,
     bool temArquivo = false,
+    String formatoArquivo = '.pdf',
     required List<String> tags,
     required int notaRelevancia,
   }) {
@@ -145,6 +148,7 @@ class Certificado {
       urlDocumento: urlDocumento,
       uploadDocumento: uploadDocumento,
       temArquivo: temArquivo,
+      formatoArquivo: formatoArquivo,
       tags: tags,
       notaRelevancia: notaRelevancia,
     );
@@ -162,6 +166,7 @@ class Certificado {
       'cargaHoraria': cargaHoraria,
       'urlDocumento': urlDocumento,
       'temArquivo': temArquivo,
+      'formatoArquivo': formatoArquivo,
       'tags': tags,
       'notaRelevancia': notaRelevancia,
     };
@@ -181,6 +186,7 @@ class Certificado {
       cargaHoraria: map['cargaHoraria'] as int?,
       urlDocumento: map['urlDocumento'] as String?,
       temArquivo: map['temArquivo'] as bool? ?? false,
+      formatoArquivo: map['formatoArquivo'] as String? ?? '.pdf',
       tags: List<String>.from((map['tags'] as List?) ?? []),
       notaRelevancia: map['notaRelevancia'] as int? ?? 1,
     );

--- a/lib/features/certificados/presentation/certificado_details_view.dart
+++ b/lib/features/certificados/presentation/certificado_details_view.dart
@@ -12,6 +12,7 @@ import 'package:ifdex/features/certificados/widgets/certificado_cover.dart';
 import 'package:ifdex/features/certificados/widgets/info_box.dart';
 import 'package:ifdex/shared/widgets/app_snack_bar.dart';
 import 'certificado_form_view.dart';
+import 'certificado_document_view.dart';
 
 /// Tela de visualização read-only de um [Certificado].
 ///
@@ -268,7 +269,7 @@ class _Content extends ConsumerWidget {
               AppSnackBar.show(
                 context,
                 type: SnackType.info,
-                message: 'Baixando arquivo...',
+                message: 'Obtendo acesso seguro ao documento...',
               );
               try {
                 final repo = ref.read(certificadoRepositoryProvider);
@@ -276,10 +277,15 @@ class _Content extends ConsumerWidget {
                 if (!context.mounted) return;
 
                 if (bytes != null) {
-                  AppSnackBar.show(
+                  ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                  await Navigator.push(
                     context,
-                    type: SnackType.success,
-                    message: 'Download concluído. (Integração PDF na Fase 3)',
+                    MaterialPageRoute<void>(
+                      builder: (_) => CertificadoDocumentView(
+                        titulo: certificado.titulo,
+                        documentBytes: bytes,
+                      ),
+                    ),
                   );
                 } else {
                   AppSnackBar.show(
@@ -293,7 +299,7 @@ class _Content extends ConsumerWidget {
                 AppSnackBar.show(
                   context,
                   type: SnackType.error,
-                  message: 'Erro ao baixar o arquivo. Tente novamente.',
+                  message: 'Erro ao acessar o arquivo. Tente novamente.',
                 );
               }
             },

--- a/lib/features/certificados/presentation/certificado_details_view.dart
+++ b/lib/features/certificados/presentation/certificado_details_view.dart
@@ -273,7 +273,7 @@ class _Content extends ConsumerWidget {
               );
               try {
                 final repo = ref.read(certificadoRepositoryProvider);
-                final bytes = await repo.carregarArquivo(certificado.id);
+                final bytes = await repo.carregarArquivo(certificado);
                 if (!context.mounted) return;
 
                 if (bytes != null) {

--- a/lib/features/certificados/presentation/certificado_document_view.dart
+++ b/lib/features/certificados/presentation/certificado_document_view.dart
@@ -5,6 +5,8 @@ import 'package:pdfrx/pdfrx.dart';
 import 'package:ifdex/shared/theme/app_theme.dart';
 import 'package:ifdex/shared/widgets/app_text.dart';
 import 'package:ifdex/shared/utils/file_type_detector.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:file_saver/file_saver.dart';
 
 /// Tela dedicada à visualização em tela cheia de Documentos (PDF, JPG, PNG).
 /// Carrega o arquivo a partir dos bytes armazenados em memória e verifica sua assinatura real.
@@ -24,18 +26,215 @@ class CertificadoDocumentView extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: AppColors.surface,
-      appBar: AppBar(
-        title: AppText(
-          titulo,
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-          color: AppColors.textOnPrimary,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buildTopBar(context, _getExtensao(fileType)),
+            Expanded(child: _buildBody(fileType)),
+          ],
         ),
       ),
-      body: _buildBody(fileType),
     );
+  }
+
+  String _getExtensao(DocumentType type) {
+    switch (type) {
+      case DocumentType.pdf:
+        return '.pdf';
+      case DocumentType.jpeg:
+        return '.jpg';
+      case DocumentType.png:
+        return '.png';
+      case DocumentType.unknown:
+        return '.bin';
+    }
+  }
+
+  Widget _buildTopBar(BuildContext context, String extensao) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        border: Border(bottom: BorderSide(color: AppColors.divider, width: 1)),
+        boxShadow: [
+          BoxShadow(
+            color: Color(0x0A000000), // 4% opacity (soft elevation)
+            blurRadius: 4,
+            offset: Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: const Icon(
+              Icons.arrow_back_rounded,
+              color: AppColors.textSecondary,
+            ),
+            tooltip: 'Voltar',
+          ),
+          const SizedBox(width: 8),
+          Image.asset(
+            'assets/logo_transparent.png',
+            height: 28,
+            fit: BoxFit.contain,
+            errorBuilder: (context, error, stackTrace) =>
+                const Icon(Icons.account_balance, color: AppColors.primary),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: AppText(
+              titulo,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: AppColors.textPrimary,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            onPressed: () => _compartilharArquivo(context, extensao),
+            icon: const Icon(
+              Icons.share_rounded,
+              color: AppColors.primary,
+              size: 22,
+            ),
+            tooltip: 'Compartilhar Arquivo',
+          ),
+          const SizedBox(width: 4),
+          ElevatedButton.icon(
+            onPressed: () => _baixarArquivoFisico(context, extensao),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              foregroundColor: AppColors.textOnPrimary,
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            ),
+            icon: const Icon(Icons.download_rounded, size: 20),
+            label: const AppText(
+              'Baixar',
+              fontWeight: FontWeight.w600,
+              color: AppColors.textOnPrimary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _compartilharArquivo(
+    BuildContext context,
+    String extensao,
+  ) async {
+    try {
+      final String nomeSaneado = titulo
+          .replaceAll(RegExp(r'[^a-zA-Z0-9\s-]'), '')
+          .trim()
+          .replaceAll(' ', '_');
+      final String nomeArquivo =
+          '${nomeSaneado.isEmpty ? "documento" : nomeSaneado}$extensao';
+
+      final xFile = XFile.fromData(
+        documentBytes,
+        name: nomeArquivo,
+        mimeType: _getMimeType(extensao),
+      );
+
+      // ignore: deprecated_member_use
+      await Share.shareXFiles([xFile], text: 'Documento IFdex: $titulo');
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: AppText(
+              'Erro ao compartilhar: $e',
+              color: AppColors.surface,
+            ),
+            backgroundColor: AppColors.error,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _baixarArquivoFisico(
+    BuildContext context,
+    String extensao,
+  ) async {
+    try {
+      final String nomeSaneado = titulo
+          .replaceAll(RegExp(r'[^a-zA-Z0-9\s-]'), '')
+          .trim()
+          .replaceAll(' ', '_');
+      final String nomeBase = nomeSaneado.isEmpty
+          ? 'documento_ifdex'
+          : nomeSaneado;
+
+      MimeType mimeType;
+      switch (extensao) {
+        case '.pdf':
+          mimeType = MimeType.pdf;
+          break;
+        case '.png':
+          mimeType = MimeType.png;
+          break;
+        case '.jpg':
+        case '.jpeg':
+          mimeType = MimeType.jpeg;
+          break;
+        default:
+          mimeType = MimeType.other;
+      }
+
+      final extLimpa = extensao.replaceAll('.', '');
+
+      await FileSaver.instance.saveFile(
+        name: '$nomeBase.$extLimpa',
+        bytes: documentBytes,
+        fileExtension: extLimpa,
+        mimeType: mimeType,
+      );
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: AppText(
+              'Download iniciado com sucesso.',
+              color: AppColors.surface,
+            ),
+            backgroundColor: AppColors.success,
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: AppText('Erro ao baixar: $e', color: AppColors.surface),
+            backgroundColor: AppColors.error,
+          ),
+        );
+      }
+    }
+  }
+
+  String _getMimeType(String extensao) {
+    switch (extensao) {
+      case '.pdf':
+        return 'application/pdf';
+      case '.png':
+        return 'image/png';
+      case '.jpg':
+      case '.jpeg':
+        return 'image/jpeg';
+      default:
+        return 'application/octet-stream';
+    }
   }
 
   Widget _buildBody(DocumentType type) {

--- a/lib/features/certificados/presentation/certificado_document_view.dart
+++ b/lib/features/certificados/presentation/certificado_document_view.dart
@@ -1,0 +1,150 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdfrx/pdfrx.dart';
+import 'package:ifdex/shared/theme/app_theme.dart';
+import 'package:ifdex/shared/widgets/app_text.dart';
+import 'package:ifdex/shared/utils/file_type_detector.dart';
+
+/// Tela dedicada à visualização em tela cheia de Documentos (PDF, JPG, PNG).
+/// Carrega o arquivo a partir dos bytes armazenados em memória e verifica sua assinatura real.
+class CertificadoDocumentView extends StatelessWidget {
+  final String titulo;
+  final Uint8List documentBytes;
+
+  const CertificadoDocumentView({
+    super.key,
+    required this.titulo,
+    required this.documentBytes,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final fileType = FileTypeDetector.detect(documentBytes);
+
+    return Scaffold(
+      backgroundColor: AppColors.surface,
+      appBar: AppBar(
+        title: AppText(
+          titulo,
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          color: AppColors.textOnPrimary,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+      body: _buildBody(fileType),
+    );
+  }
+
+  Widget _buildBody(DocumentType type) {
+    switch (type) {
+      case DocumentType.pdf:
+        return PdfViewer.data(
+          documentBytes,
+          sourceName: titulo,
+          params: PdfViewerParams(
+            backgroundColor: AppColors.background,
+            loadingBannerBuilder: (context, bytesDownloaded, totalBytes) {
+              return const Center(
+                child: CircularProgressIndicator(color: AppColors.primary),
+              );
+            },
+            errorBannerBuilder: (context, error, stackTrace, documentRef) {
+              return Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      color: AppColors.error,
+                      size: 48,
+                    ),
+                    const SizedBox(height: 16),
+                    AppText(
+                      'Falha ao renderizar o documento PDF.\n'
+                      'Tamanho: ${documentBytes.length} bytes\n'
+                      'Erro interno: $error',
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+
+      case DocumentType.jpeg:
+      case DocumentType.png:
+        return Center(
+          child: InteractiveViewer(
+            child: Image.memory(
+              documentBytes,
+              fit: BoxFit.contain,
+              errorBuilder: (context, error, stackTrace) {
+                return const Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.broken_image,
+                        color: AppColors.error,
+                        size: 48,
+                      ),
+                      SizedBox(height: 16),
+                      AppText(
+                        'Falha ao renderizar a imagem.\nO arquivo pode estar corrompido.',
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+      case DocumentType.unknown:
+        // Exibe erro educado se for arquivo corrompido ou página HTML do Sispubli
+        return Center(
+          child: Padding(
+            padding: const EdgeInsets.all(32.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.warning_amber_rounded,
+                  color: AppColors.error,
+                  size: 64,
+                ),
+                const SizedBox(height: 24),
+                const AppText(
+                  'Arquivo Corrompido ou Inválido',
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                const AppText(
+                  'A API de importação (Sispubli) retornou dados inválidos ou uma página de erro em vez do documento real.\n\n'
+                  'Por favor, exclua este certificado e tente importá-lo novamente mais tarde.',
+                  textAlign: TextAlign.center,
+                  color: AppColors.textSecondary,
+                  maxLines: 5,
+                ),
+                const SizedBox(height: 32),
+                AppText(
+                  'Tamanho recebido: ${documentBytes.length} bytes\n'
+                  'Os primeiros bytes não correspondem a PDF, JPG ou PNG.',
+                  fontSize: 12,
+                  color: AppColors.textSecondary,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        );
+    }
+  }
+}

--- a/lib/features/certificados/presentation/certificados_view_model.dart
+++ b/lib/features/certificados/presentation/certificados_view_model.dart
@@ -152,13 +152,15 @@ class CertificadosViewModel extends _$CertificadosViewModel {
     }
   }
 
-  Future<void> remover(String id) async {
+  Future<void> remover(Certificado certificado) async {
     final repository = ref.read(certificadoRepositoryProvider);
-    await repository.remover(id);
+    await repository.remover(certificado);
 
     if (state is AsyncData) {
       final listaAtual = state.requireValue;
-      final novaLista = listaAtual.where((c) => c.id != id).toList();
+      final novaLista = listaAtual
+          .where((c) => c.id != certificado.id)
+          .toList();
       state = AsyncData(novaLista);
     }
   }

--- a/lib/features/home/presentation/home_mobile_view.dart
+++ b/lib/features/home/presentation/home_mobile_view.dart
@@ -64,7 +64,7 @@ class HomeMobileView extends ConsumerWidget {
                     onRemove: () async {
                       await ref
                           .read(certificadosViewModelProvider.notifier)
-                          .remover(c.id);
+                          .remover(c);
                       if (context.mounted) {
                         AppSnackBar.show(
                           context,

--- a/lib/features/home/presentation/home_web_view.dart
+++ b/lib/features/home/presentation/home_web_view.dart
@@ -207,90 +207,113 @@ class _TopBar extends ConsumerWidget {
         color: AppColors.surface,
         border: Border(bottom: BorderSide(color: AppColors.divider)),
       ),
-      child: Row(
-        children: [
-          AppText.headline('Dashboard Acadêmico'),
-          const Spacer(),
-          SizedBox(
-            width: 300,
-            child: AppSearchBar(
-              initialValue: ref.read(buscaHomeProvider),
-              onChanged: (val) {
-                ref.read(buscaHomeProvider.notifier).setQuery(val);
-              },
-            ),
-          ),
-          const SizedBox(width: 16),
-          IconButton(
-            onPressed: () {
-              showDialog<void>(
-                context: context,
-                builder: (_) => Dialog(
-                  backgroundColor: Colors.transparent,
-                  insetPadding: const EdgeInsets.all(24),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 450),
-                    child: const AppFiltrosBottomSheet(),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minWidth: constraints.maxWidth),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  AppText.headline('Dashboard Acadêmico'),
+                  Row(
+                    children: [
+                      const SizedBox(width: 16),
+                      SizedBox(
+                        width: 260,
+                        child: AppSearchBar(
+                          initialValue: ref.read(buscaHomeProvider),
+                          onChanged: (val) {
+                            ref.read(buscaHomeProvider.notifier).setQuery(val);
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      IconButton(
+                        onPressed: () {
+                          showDialog<void>(
+                            context: context,
+                            builder: (_) => Dialog(
+                              backgroundColor: Colors.transparent,
+                              insetPadding: const EdgeInsets.all(24),
+                              child: ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  maxWidth: 450,
+                                ),
+                                child: const AppFiltrosBottomSheet(),
+                              ),
+                            ),
+                          );
+                        },
+                        tooltip: 'Filtrar e Ordenar',
+                        icon: const Icon(
+                          Icons.tune,
+                          color: AppColors.primary,
+                          size: 24,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      ElevatedButton.icon(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute<void>(
+                              builder: (_) => const CertificadoFormView(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.add, size: 18),
+                        label: const AppText(
+                          'Novo Certificado',
+                          color: AppColors.textOnPrimary,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      OutlinedButton.icon(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute<void>(
+                              builder: (_) => const SispubliImportView(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(
+                          Icons.cloud_download_outlined,
+                          size: 18,
+                          color: AppColors.primary,
+                        ),
+                        label: const AppText(
+                          'Importar do IFS',
+                          color: AppColors.primary,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      IconButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute<void>(
+                              builder: (_) => const ProfileView(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(
+                          Icons.account_circle,
+                          color: AppColors.primary,
+                          size: 32,
+                        ),
+                      ),
+                    ],
                   ),
-                ),
-              );
-            },
-            tooltip: 'Filtrar e Ordenar',
-            icon: const Icon(Icons.tune, color: AppColors.primary, size: 24),
-          ),
-          const SizedBox(width: 12),
-          ElevatedButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute<void>(
-                  builder: (_) => const CertificadoFormView(),
-                ),
-              );
-            },
-            icon: const Icon(Icons.add, size: 18),
-            label: const AppText(
-              'Novo Certificado',
-              color: AppColors.textOnPrimary,
-              fontWeight: FontWeight.w500,
+                ],
+              ),
             ),
-          ),
-          const SizedBox(width: 8),
-          OutlinedButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute<void>(
-                  builder: (_) => const SispubliImportView(),
-                ),
-              );
-            },
-            icon: const Icon(
-              Icons.cloud_download_outlined,
-              size: 18,
-              color: AppColors.primary,
-            ),
-            label: const AppText(
-              'Importar do IFS',
-              color: AppColors.primary,
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-          const SizedBox(width: 16),
-          IconButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute<void>(builder: (_) => const ProfileView()),
-              );
-            },
-            icon: const Icon(
-              Icons.account_circle,
-              color: AppColors.primary,
-              size: 32,
-            ),
-          ),
-        ],
+          );
+        },
       ),
     );
   }

--- a/lib/features/home/presentation/home_web_view.dart
+++ b/lib/features/home/presentation/home_web_view.dart
@@ -396,7 +396,7 @@ class _AreaPrincipal extends ConsumerWidget {
                           onRemove: () async {
                             await ref
                                 .read(certificadosViewModelProvider.notifier)
-                                .remover(c.id);
+                                .remover(c);
                             if (context.mounted) {
                               AppSnackBar.show(
                                 context,

--- a/lib/features/sispubli/data/sispubli_datasource.dart
+++ b/lib/features/sispubli/data/sispubli_datasource.dart
@@ -107,14 +107,16 @@ class SispubliDatasource {
     }
   }
 
-  /// GET /api/pdf/{ticket}
-  ///
   /// Baixa os bytes crus do PDF via túnel seguro.
   /// O [urlDownload] já contém a URL completa.
   Future<Uint8List> baixarPdf(String urlDownload) async {
     try {
+      final urlFinal = urlDownload.startsWith('http')
+          ? urlDownload
+          : '$baseUrl${urlDownload.startsWith('/') ? '' : '/'}$urlDownload';
+
       final response = await _dio.get<List<int>>(
-        urlDownload,
+        urlFinal,
         options: Options(responseType: ResponseType.bytes),
       );
 

--- a/lib/shared/utils/file_type_detector.dart
+++ b/lib/shared/utils/file_type_detector.dart
@@ -1,0 +1,34 @@
+import 'dart:typed_data';
+
+enum DocumentType { pdf, png, jpeg, unknown }
+
+class FileTypeDetector {
+  /// Analisa os "Magic Bytes" de um array de bytes para determinar
+  /// com precisão o tipo de arquivo real, ignorando a extensão.
+  static DocumentType detect(Uint8List bytes) {
+    if (bytes.length < 4) return DocumentType.unknown;
+
+    // PDF: %PDF (25 50 44 46)
+    if (bytes[0] == 0x25 &&
+        bytes[1] == 0x50 &&
+        bytes[2] == 0x44 &&
+        bytes[3] == 0x46) {
+      return DocumentType.pdf;
+    }
+
+    // PNG: \x89PNG (89 50 4E 47)
+    if (bytes[0] == 0x89 &&
+        bytes[1] == 0x50 &&
+        bytes[2] == 0x4E &&
+        bytes[3] == 0x47) {
+      return DocumentType.png;
+    }
+
+    // JPEG: FF D8 FF
+    if (bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF) {
+      return DocumentType.jpeg;
+    }
+
+    return DocumentType.unknown;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1000,6 +1000,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdfium_dart:
+    dependency: transitive
+    description:
+      name: pdfium_dart
+      sha256: "86e95c66b09f3245b95c4924f2edce8d4f7c9786876e5c5ee8e36b104a94bbb0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
+  pdfium_flutter:
+    dependency: transitive
+    description:
+      name: pdfium_flutter
+      sha256: "420ba8e7673b54da387ceeeb18a72c8bc6e4452128dbb391dca900c748f9e9ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  pdfrx:
+    dependency: "direct main"
+    description:
+      name: pdfrx
+      sha256: e0ca318004c3f32144db8e74fa612abb80ebe79004677293af74ed9af119f47f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.4"
+  pdfrx_engine:
+    dependency: transitive
+    description:
+      name: pdfrx_engine
+      sha256: "89865e158ced818690ab207a13a34a65803cd67ee1bec9f5f87838eb5a79600b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.3"
   petitparser:
     dependency: transitive
     description:
@@ -1301,6 +1333,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.15.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1519,4 +1559,4 @@ packages:
     version: "2.1.1"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.41.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -417,6 +417,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.3.7"
+  file_saver:
+    dependency: "direct main"
+    description:
+      name: file_saver
+      sha256: "68c9a085d9bb4546e0a31d1e583a48d7c17a6987d538788ea064f0043b1fc02d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -1176,6 +1184,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   flutter_image_compress: ^2.4.0
   supabase_flutter: ^2.15.0
   dio: ^5.9.2
+  pdfrx: ^2.4.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,8 @@ dependencies:
   supabase_flutter: ^2.15.0
   dio: ^5.9.2
   pdfrx: ^2.4.4
+  share_plus: ^12.0.2
+  file_saver: ^0.4.0
 
 dev_dependencies:
   flutter_test:

--- a/test/features/certificados/presentation/certificados_view_model_test.dart
+++ b/test/features/certificados/presentation/certificados_view_model_test.dart
@@ -23,12 +23,14 @@ class FakeCertificadoRepository implements CertificadoRepository {
   }
 
   @override
-  Future<void> remover(String id) async {
-    _items.removeWhere((c) => c.id == id);
+  Future<void> remover(Certificado certificado) async {
+    _items.removeWhere((c) => c.id == certificado.id);
   }
 
   @override
-  Future<Uint8List?> carregarArquivo(String certificadoId) async => null;
+  Future<Uint8List?> carregarArquivo(Certificado certificado) async {
+    return null;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -132,7 +134,7 @@ void main() {
       final countBefore = stateList.length;
 
       final notifier = container.read(certificadosViewModelProvider.notifier);
-      await notifier.remover(alvo.id);
+      await notifier.remover(alvo);
 
       final countAfter = container
           .read(certificadosViewModelProvider)


### PR DESCRIPTION
<!-- AGENTE MCP / IA: Ao analisar este Pull Request, verifique de forma autônoma se o código viola a regra de não utilizar tipos 'dynamic'. Se o PR alterar a pasta lib/views/ ou lib/widgets/, exija a presença de screenshots de prova visual no corpo da descrição abaixo. -->

# 🔗 Link para a Issue resolvida

Closes #16

## 📋 Checklist Obrigatório

Antes de colocar seu PR para revisão, ateste que cumpriu os padrões do repositório:

- [x] Eu rodei `make check` e não há erros de Linter ou formatação.
- [x] Eu escrevi testes automatizados para essa alteração (se aplicável).
- [x] Meu código não utiliza `dynamic` e respeita as regras de tipagem estrita.

---

## 🖼️ Prova Visual (A Regra do "Me Prove")

Se você alterou elementos de interface do Flutter (`lib/views/` ou `lib/widgets/`), é **obrigatório** anexar evidências visuais do Antes e Depois. Isso elimina o atrito de compilação apenas para revisão de UI.

> **Visualizador de PDF Nativo:**
> *(Por favor, anexe o print do `media__1782173867989.png` que geramos aqui para validar a nova TopBar limpa contendo o Título redimensionado, o ícone de Compartilhamento e o botão nativo de Baixar)*

---

## 🤔 Reflexão Estratégica

Evite a "aprovação no piloto automático" respondendo:

**1. Qual foi o caso extremo (edge case) que você considerou ao codificar essa funcionalidade ou teste?**
> Considere a possibilidade de a API (Sispubli) retornar erros HTTP em HTML (como 404 ou páginas de manutenção) disfarçados de stream de bytes durante a extração direta do documento. Isso faria a engine do visualizador corromper ou crashar o app. Para mitigar esse edge case, tratamos e interceptamos falhas de rendering com um estado seguro de falha (`onDocumentLoadFailed` no `SfPdfViewer` e fallback seguro para imagens), exibindo ao usuário uma interface amigável e clara indicando "Arquivo Corrompido ou Inválido". Além disso, tratamos as chamadas da plataforma nativa no Windows lidando com `MimeTypes` explícitos e definindo o `fileExtension` para garantir salvamentos corretos que o sistema operacional consiga ler (evitando arquivos `.bin` ocultos).

**2. Foi deixado algum débito técnico consciente nesta entrega? Se sim, qual e o porquê?**
> Sim. Optamos conscientemente por carregar todo o vetor de stream na memória RAM (`documentBytes`) para gerenciar as visualizações e não manter histórico residual persistido (sujando o disco). Para documentos convencionais, isso consome 1 a 3 MB de RAM, o que é insignificante. O débito fica para eventuais PDFs gigantes (ex: +30MB), que poderão invocar um pico indesejado no garbage collector do Flutter na web. Esse trade-off foi aceito para aderir à premissa do sistema de não salvar arquivos de forma estática no armazenamento do celular/computador do usuário antes de sua autorização (botão baixar). Otimizações de paginação via file buffers podem ser introduzidas numa refatoração futura, caso necessário.
