### PR TITLE
ci: corrige falso negativo 400 do Firebase forçando Node 20

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -27,6 +27,8 @@ jobs:
       # AQUI ESTÁ A CORREÇÃO: @v0
       - name: Publicar no Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_IFDEX_APP }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -22,6 +22,8 @@ jobs:
         run: flutter build web
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         continue-on-error: true
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
### Descrição clara do que é a feature

Essa Pull Request injeta a variável de ambiente `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` nas rotinas de deploy do Firebase Hosting.

### Qual problema ela resolve?

O GitHub Actions atualizou recentemente seus *runners* (`ubuntu-latest` e cia) forçando o uso do **Node.js 24**, deprecando o Node 20. Ocorre que o Firebase CLI e a action `FirebaseExtended/action-hosting-deploy` sofrem de um bug crítico de rede no Node 24, causando sucessivos erros `premature close error` que acabam engatilhando retentativas infinitas que culminam no Erro 400 (`is the current active version`).

Com esse *escape hatch* oficial do GitHub, forçamos a esteira a voltar para o Node 20, estabilizando os deploys de PR e da branch `main`.

### Critérios de Aceite

- [x] Variável adicionada ao workflow de Pull Request.
- [x] Variável adicionada ao workflow de Merge/Live.
