### PR TITLE
ci: corrige deploy do Firebase forçando setup-node@v4 explícito

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -25,10 +25,13 @@ jobs:
         run: flutter build web
 
       # AQUI ESTÁ A CORREÇÃO: @v0
+      - name: Setup Node.js (Fix Firebase CLI Network Bug)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Publicar no Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_IFDEX_APP }}'

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -81,6 +81,11 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         run: flutter build apk --release --build-number=${{ github.run_number }}
 
+      - name: Setup Node.js (Fix Firebase CLI Network Bug)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Instalar Firebase CLI no Servidor
         run: npm install -g firebase-tools
 

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -21,9 +21,12 @@ jobs:
       - name: Compilar versão Web
         run: flutter build web
 
+      - name: Setup Node.js (Fix Firebase CLI Network Bug)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         continue-on-error: true
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
### Descrição clara do que é a feature
A PR anterior (#54) foi mergeada antes da submissão final da correção definitiva (que usa a action `setup-node` explícita). Essa PR mescla o restante da branch que contém a solução validada e definitiva para corrigir o `premature close error` / Erro 400 do Firebase Hosting e Firebase App Distribution.

### Qual problema ela resolve?
Remove a variável de ambiente inútil (que afeta apenas o wrapper do Github Actions) e injeta fisicamente o Node.js 20 na máquina virtual do Ubuntu *antes* de rodar a CLI do Firebase via `npx` e `npm`. Isso garante a estabilidade dos requests TCP/IP e Keep-Alive que quebram no Node 24.

### Critérios de Aceite
- [x] Aplica a correção de `setup-node` no `firebase-hosting-pull-request.yml`
- [x] Aplica a correção de `setup-node` no `firebase-hosting-merge.yml`
- [x] Protege o job de Android (`build_and_distribute_android`) contra o mesmo bug de rede.